### PR TITLE
Improve README usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,19 @@
 
 OPC Dash Refactored
 
-## Setup
+## Requirements
 
-Install the required Python packages:
+The application depends on the following Python packages:
+
+- `dash`
+- `dash-bootstrap-components`
+- `python-opcua`
+- `plotly`
+- `pandas`
+- `numpy`
+- `python-i18n`
+
+Install them with:
 
 ```bash
 pip install -r requirements.txt
@@ -15,6 +25,11 @@ pip install -r requirements.txt
 Run the dashboard application:
 
 ```bash
-python run_dashboard.py
+python EnpresorOPCDataViewBeforeRestructure.py
 ```
+
+Alternatively you can start the same dashboard with `python run_dashboard.py`.
+
+Images used by the dashboard should be placed in an `assets/` directory that
+resides next to the script so Dash can serve them automatically.
 


### PR DESCRIPTION
## Summary
- list all required Python packages in a new Requirements section
- add instructions for running `EnpresorOPCDataViewBeforeRestructure.py`
- note that images should be placed under an `assets/` directory

## Testing
- `python -m py_compile EnpresorOPCDataViewBeforeRestructure.py run_dashboard.py dashboard/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685c3a8294fc8327ada5733a5d4284e8