### PR TITLE
Update README with export dir info

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ Images used by the dashboard should be placed in an `assets/` directory that
 resides next to the script so Dash can serve them automatically.
 The provided `EnpresorMachine.png` image is included in this `assets/` folder.
 
+Metrics and control logs written by the dashboard are automatically saved
+to an `exports/` directory. This folder will be created at runtime if it does
+not already exist.
+
+The `Audiowide-Regular.ttf` font used when generating PDF reports is kept in
+the repository root. Ensure this file remains in place so the report generator
+can locate it.
+


### PR DESCRIPTION
## Summary
- document automatic exports to `exports/`
- note that `Audiowide-Regular.ttf` stays in repo root for PDF reports

## Testing
- `python -m py_compile EnpresorOPCDataViewBeforeRestructure.py generate_reportTest.py hourly_data_saving.py run_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_685c42d662b0832792fa8a85f5a3e937