### PR TITLE
Update dashboard imports for startup helpers

### DIFF
--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -13,6 +13,8 @@ from .opc_client import (
     pause_update_thread,
     resume_update_thread,
 )
+from .startup import start_auto_reconnection, delayed_startup_connect
+from .images import load_saved_image
 from .settings import (
     load_display_settings,
     save_display_settings,
@@ -53,6 +55,8 @@ __all__ = [
     "run_async",
     "pause_update_thread",
     "resume_update_thread",
+    "start_auto_reconnection",
+    "delayed_startup_connect",
     "load_display_settings",
     "save_display_settings",
     "load_ip_addresses",
@@ -71,6 +75,7 @@ __all__ = [
     "convert_capacity_to_lbs",
     "convert_capacity_from_lbs",
     "capacity_unit_label",
+    "load_saved_image",
     "render_new_dashboard",
     "render_floor_machine_layout_with_customizable_names",
     "render_floor_machine_layout_enhanced_with_selection",

--- a/dashboard/images.py
+++ b/dashboard/images.py
@@ -1,0 +1,5 @@
+"""Image helper functions for the dashboard."""
+
+from EnpresorOPCDataViewBeforeRestructure import load_saved_image
+
+__all__ = ["load_saved_image"]

--- a/dashboard/startup.py
+++ b/dashboard/startup.py
@@ -1,0 +1,8 @@
+"""Startup utilities for the dashboard."""
+
+from EnpresorOPCDataViewBeforeRestructure import (
+    start_auto_reconnection,
+    delayed_startup_connect,
+)
+
+__all__ = ["start_auto_reconnection", "delayed_startup_connect"]

--- a/run_dashboard.py
+++ b/run_dashboard.py
@@ -17,12 +17,9 @@ except ImportError:  # pragma: no cover - Python 3.12+
 
 from dashboard import app
 from dashboard.opc_client import run_async, disconnect_from_server
-from EnpresorOPCDataViewBeforeRestructure import (
-    start_auto_reconnection,
-    delayed_startup_connect,
-    load_saved_image,
-    app_state,
-)
+from dashboard.startup import start_auto_reconnection, delayed_startup_connect
+from dashboard.images import load_saved_image
+from dashboard.state import app_state
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- expose new `startup` and `images` helpers in the dashboard package
- use these helpers in `run_dashboard.py` rather than importing from the legacy file

## Testing
- `pytest -q`
- `python run_dashboard.py --no-open-browser --debug` *(fails: `No module named 'dash'`)*

------
https://chatgpt.com/codex/tasks/task_e_685d8bf199248327838e6a21419ed32b