### PR TITLE
Implement reconnection helpers

### DIFF
--- a/dashboard/reconnection.py
+++ b/dashboard/reconnection.py
@@ -1,18 +1,101 @@
-"""Placeholder reconnection helpers."""
+"""OPC UA reconnection utilities reused by the dashboard."""
+
+from __future__ import annotations
 
 import logging
+import time
+from threading import Thread
+from typing import Optional
+
+from .state import app_state
+from .opc_client import connect_to_server, run_async, resume_update_thread
+
 
 logger = logging.getLogger(__name__)
 
 
-def start_auto_reconnection():
-    """Begin automatic reconnection loop (stub)."""
-    logger.warning("start_auto_reconnection is not implemented")
+RECONNECT_INTERVAL = 10
 
 
-def delayed_startup_connect():
-    """Connect to the OPC server after a delay (stub)."""
-    logger.warning("delayed_startup_connect is not implemented")
+def _reconnection_loop() -> None:
+    """Background thread attempting to reconnect when disconnected."""
+
+    logger.info("Auto-reconnection thread started")
+    delay = RECONNECT_INTERVAL
+
+    while not app_state.thread_stop_flag:
+        try:
+            server_url: Optional[str] = getattr(app_state, "server_url", None)
+            server_name: Optional[str] = getattr(app_state, "server_name", None)
+
+            if not app_state.connected and server_url:
+                logger.info("Attempting reconnect to %s", server_url)
+                success = False
+                try:
+                    success = run_async(connect_to_server(server_url, server_name))
+                except Exception as exc:  # pragma: no cover - network dependent
+                    logger.error("Auto-reconnection attempt failed: %s", exc)
+
+                if success:
+                    logger.info("Reconnected successfully")
+                    resume_update_thread()
+                    delay = RECONNECT_INTERVAL
+                else:
+                    delay = min(60, delay * 2)
+                    logger.debug(
+                        "Reconnection failed, retrying in %s seconds", delay
+                    )
+            else:
+                delay = RECONNECT_INTERVAL
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            logger.error("Error in auto-reconnection loop: %s", exc)
+            delay = min(60, delay * 2)
+
+        time.sleep(delay)
+
+    logger.info("Auto-reconnection thread stopped")
+
+
+def start_auto_reconnection() -> None:
+    """Begin the automatic reconnection loop in a daemon thread."""
+
+    if getattr(app_state, "reconnection_thread", None) and getattr(
+        app_state.reconnection_thread, "is_alive", lambda: False
+    )():
+        logger.debug("Auto-reconnection thread already running")
+        return
+
+    app_state.thread_stop_flag = False
+    thread = Thread(target=_reconnection_loop)
+    thread.daemon = True
+    thread.start()
+
+    app_state.reconnection_thread = thread
+    logger.info("Started auto-reconnection thread")
+
+
+def delayed_startup_connect(delay: int = 3) -> None:
+    """Connect to the OPC server after a short delay."""
+
+    time.sleep(delay)
+
+    server_url: Optional[str] = getattr(app_state, "server_url", None)
+    server_name: Optional[str] = getattr(app_state, "server_name", None)
+
+    if not server_url:
+        logger.info("No server URL configured for startup connection")
+        return
+
+    try:
+        logger.info("Performing startup connection to %s", server_url)
+        connected = run_async(connect_to_server(server_url, server_name))
+        if connected:
+            resume_update_thread()
+            logger.info("Startup connection successful")
+        else:
+            logger.warning("Startup connection failed")
+    except Exception as exc:  # pragma: no cover - network dependent
+        logger.error("Startup connection error: %s", exc)
 
 
 def load_saved_image():

--- a/tests/test_dashboard_utils.py
+++ b/tests/test_dashboard_utils.py
@@ -192,3 +192,40 @@ def test_layout_functions_return_none(monkeypatch):
     assert (
         layout.render_floor_machine_layout_enhanced_with_selection() is None
     )
+
+
+def test_reconnection_helpers_execute(monkeypatch):
+    calls = {}
+
+    async def fake_connect(url, server_name=None):
+        calls["connect"] = url
+        return True
+
+    def fake_run_async(coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    state_obj = SimpleNamespace(thread_stop_flag=False)
+    patches = {
+        "connect_to_server": fake_connect,
+        "run_async": fake_run_async,
+        "resume_update_thread": lambda: None,
+        "time": types.SimpleNamespace(sleep=lambda x: None),
+        "app_state": state_obj,
+    }
+
+    legacy, _, _, _, startup = load_modules(monkeypatch, src_patches=patches)
+    state_obj.server_url = "opc.tcp://example:4840"
+
+    startup.start_auto_reconnection()
+    state_obj.thread_stop_flag = True
+    thread = getattr(state_obj, "reconnection_thread", None)
+    if thread:
+        thread.join(timeout=0.1)
+
+    startup.delayed_startup_connect()
+
+    assert calls["connect"] == "opc.tcp://example:4840"


### PR DESCRIPTION
## Summary
- flesh out reconnection helpers with threading logic
- ensure delayed startup connection uses the same helpers
- test reconnection utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da7dad83883279ea11cd44f3aafe8