### PR TITLE
Refactor modules for layout and data export

### DIFF
--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -15,6 +15,14 @@ from .opc_client import (
 )
 from .startup import start_auto_reconnection, delayed_startup_connect
 from .images import load_saved_image
+from .machine_layout import save_layout, load_layout
+from .data_export import (
+    initialize_data_saving,
+    get_historical_data,
+    append_metrics,
+    append_control_log,
+    get_historical_control_log,
+)
 from .settings import (
     load_display_settings,
     save_display_settings,
@@ -79,4 +87,11 @@ __all__ = [
     "render_new_dashboard",
     "render_floor_machine_layout_with_customizable_names",
     "render_floor_machine_layout_enhanced_with_selection",
+    "save_layout",
+    "load_layout",
+    "initialize_data_saving",
+    "get_historical_data",
+    "append_metrics",
+    "append_control_log",
+    "get_historical_control_log",
 ]

--- a/dashboard/data_export.py
+++ b/dashboard/data_export.py
@@ -1,0 +1,20 @@
+"""Data export helpers wrapping ``hourly_data_saving`` utilities."""
+from __future__ import annotations
+
+from typing import Optional, List, Dict, Any
+
+from hourly_data_saving import (
+    initialize_data_saving,
+    get_historical_data,
+    append_metrics,
+    append_control_log,
+    get_historical_control_log,
+)
+
+__all__ = [
+    "initialize_data_saving",
+    "get_historical_data",
+    "append_metrics",
+    "append_control_log",
+    "get_historical_control_log",
+]

--- a/dashboard/machine_layout.py
+++ b/dashboard/machine_layout.py
@@ -1,0 +1,61 @@
+"""Floor and machine layout helpers."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Tuple, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+# Data directory lives in repository root next to ``run_dashboard.py``
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+LAYOUT_PATH = DATA_DIR / "floor_machine_layout.json"
+
+
+def save_layout(
+    floors_data: Dict[str, Any],
+    machines_data: Dict[str, Any],
+    path: Path = LAYOUT_PATH,
+) -> bool:
+    """Persist ``floors_data`` and ``machines_data`` to ``path``."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(
+                {
+                    "floors": floors_data,
+                    "machines": machines_data,
+                    "saved_timestamp": datetime.now().isoformat(),
+                },
+                f,
+                indent=4,
+            )
+        return True
+    except Exception as exc:  # pragma: no cover - filesystem dependent
+        logger.error("Error saving floor/machine layout: %s", exc)
+        return False
+
+
+def load_layout(
+    path: Path = LAYOUT_PATH,
+) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    """Return saved ``floors_data`` and ``machines_data`` from ``path``."""
+    try:
+        if path.exists():
+            with open(path, "r") as f:
+                data = json.load(f)
+            floors = data.get(
+                "floors",
+                {"floors": [{"id": 1, "name": "1st Floor"}], "selected_floor": "all"},
+            )
+            machines = data.get("machines", {"machines": [], "next_machine_id": 1})
+            return floors, machines
+        return None, None
+    except Exception as exc:  # pragma: no cover - filesystem dependent
+        logger.error("Error loading floor/machine layout: %s", exc)
+        return None, None
+
+__all__ = ["save_layout", "load_layout"]

--- a/run_dashboard.py
+++ b/run_dashboard.py
@@ -22,6 +22,8 @@ from dashboard import (
     start_auto_reconnection,
     delayed_startup_connect,
     load_saved_image,
+    load_layout,
+    initialize_data_saving,
 )
 from dashboard.layout import render_new_dashboard
 from dashboard.state import app_state
@@ -88,6 +90,16 @@ if __name__ == "__main__":
         saved_image = load_saved_image()
         if saved_image:
             logger.info("Loaded saved custom image")
+
+        floors_data, machines_data = load_layout()
+        if floors_data or machines_data:
+            logger.info("Loaded saved floor/machine layout")
+
+        machine_ids = None
+        if machines_data and isinstance(machines_data, dict):
+            machine_ids = [m.get("id") for m in machines_data.get("machines", [])]
+
+        initialize_data_saving(machine_ids=machine_ids)
 
         import socket
 


### PR DESCRIPTION
## Summary
- add a `machine_layout` helper module for saving/loading layouts
- add a `data_export` module wrapping hourly data utilities
- export new helpers in `dashboard.__init__`
- orchestrate layout loading and data initialization in `run_dashboard.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dadb71f2483279bd560527785a85b