### PR TITLE
Wrap main dashboard layout with interval and store

### DIFF
--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -36,8 +36,19 @@ SECTION_HEIGHT2 = "250px"
 
 def render_new_dashboard() -> Any:
     """Return the main dashboard layout filled with visible sections."""
+    grid = render_main_dashboard()
 
-    return render_main_dashboard()
+    return html.Div(
+        [
+            dcc.Interval(
+                id="status-update-interval",
+                interval=1000,
+                n_intervals=0,
+            ),
+            dcc.Store(id="production-data-store"),
+            grid,
+        ]
+    )
 
 
 def render_main_dashboard() -> Any:


### PR DESCRIPTION
## Summary
- add `status-update-interval` and `production-data-store` to the new dashboard layout
- ensure `dcc` is imported alongside `html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db790c91c83279f0b0f7f4060f31d