### PR TITLE
Allow enabling Dash debug mode

### DIFF
--- a/run_dashboard.py
+++ b/run_dashboard.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
 
         app.layout = render_new_dashboard()
 
-        app.run(debug=False, use_reloader=False, host="0.0.0.0", port=8050)
+        app.run(debug=args.debug, use_reloader=False, host="0.0.0.0", port=8050)
 
     except KeyboardInterrupt:
         print("\nShutting down...")


### PR DESCRIPTION
## Summary
- pipe --debug CLI option into `app.run`

## Testing
- `pytest -q`
- `python run_dashboard.py --debug` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_685dbc827f08832798a451bcbe73a029