### PR TITLE
Add language preference store

### DIFF
--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from .settings import load_language_preference
+
 # ``dash`` is an optional dependency during testing.  These helpers fall
 # back to lightweight stubs when the package is unavailable so that the unit
 # tests can import the module without needing the real library installed.
@@ -61,6 +63,10 @@ def render_new_dashboard() -> Any:
                 n_intervals=0,
             ),
             dcc.Store(id="production-data-store"),
+            dcc.Store(
+                id="language-preference-store",
+                data=load_language_preference(),
+            ),
             grid,
         ]
     )


### PR DESCRIPTION
## Summary
- load UI language preference via settings
- include a `dcc.Store` for language preference in the layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dbeb39f20832799236d0aa5599c3c