### PR TITLE
Fix missing weight preference store

### DIFF
--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from .settings import load_language_preference
+from .settings import load_language_preference, load_weight_preference
 
 # ``dash`` is an optional dependency during testing.  These helpers fall
 # back to lightweight stubs when the package is unavailable so that the unit
@@ -63,6 +63,10 @@ def render_new_dashboard() -> Any:
                 n_intervals=0,
             ),
             dcc.Store(id="production-data-store"),
+            dcc.Store(
+                id="weight-preference-store",
+                data=load_weight_preference(),
+            ),
             dcc.Store(
                 id="language-preference-store",
                 data=load_language_preference(),

--- a/tests/test_dashboard_utils.py
+++ b/tests/test_dashboard_utils.py
@@ -198,6 +198,24 @@ def test_layout_functions_return_components(monkeypatch):
         assert hasattr(component, "children")
 
 
+def test_render_new_dashboard_has_weight_store(monkeypatch):
+    _, _, _, layout, _ = load_modules(monkeypatch)
+    comp = layout.render_new_dashboard()
+
+    def find_weight_store(node):
+        if getattr(node, "props", {}).get("id") == "weight-preference-store":
+            return True
+        children = getattr(node, "children", []) or []
+        if len(children) == 1 and isinstance(children[0], list):
+            children = children[0]
+        for child in children:
+            if find_weight_store(child):
+                return True
+        return False
+
+    assert find_weight_store(comp)
+
+
 def test_reconnection_helpers_execute(monkeypatch):
     calls = {}
 


### PR DESCRIPTION
## Summary
- load weight preference in layout
- include `weight-preference-store` in the dashboard layout
- test that the store appears in `render_new_dashboard`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dbf8041f48327b3fb382b765d6274