### PR TITLE
Add dashboard wrapper and toggle callback

### DIFF
--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -44,6 +44,7 @@ from .settings import (
     capacity_unit_label,
 )
 from .layout import (
+    render_dashboard_wrapper,
     render_new_dashboard,
     render_floor_machine_layout_with_customizable_names,
     render_floor_machine_layout_enhanced_with_selection,
@@ -84,6 +85,7 @@ __all__ = [
     "convert_capacity_from_lbs",
     "capacity_unit_label",
     "load_saved_image",
+    "render_dashboard_wrapper",
     "render_new_dashboard",
     "render_floor_machine_layout_with_customizable_names",
     "render_floor_machine_layout_enhanced_with_selection",

--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -75,6 +75,7 @@ from .settings import (
     capacity_unit_label,
 )
 from i18n import tr
+from .layout import render_new_dashboard, render_main_dashboard
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +113,26 @@ def _generate_csv_string(tags: dict) -> str:
 
 def register_callbacks() -> None:
     """Register core callbacks with the Dash app."""
+
+    @_dash_callback(
+        Output("dashboard-content", "children"),
+        Input("current-dashboard", "data"),
+    )
+    def render_dashboard(which):
+        if which == "new":
+            return render_new_dashboard()
+        return render_main_dashboard()
+
+    @_dash_callback(
+        Output("current-dashboard", "data"),
+        Input("new-dashboard-btn", "n_clicks"),
+        State("current-dashboard", "data"),
+        prevent_initial_call=False,
+    )
+    def manage_dashboard(n_clicks, current):
+        if n_clicks is None:
+            return "new"
+        return "new" if current == "main" else "main"
 
     @_dash_callback(
         Output("section-1-1", "children"),

--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -207,6 +207,18 @@ def render_main_dashboard() -> Any:
     )
 
 
+def render_dashboard_wrapper() -> Any:
+    """Return a wrapper containing dashboard switch controls."""
+
+    return html.Div(
+        [
+            dcc.Store(id="current-dashboard", data="new"),
+            dbc.Button("Toggle Dashboard", id="new-dashboard-btn"),
+            html.Div(id="dashboard-content", children=render_new_dashboard()),
+        ]
+    )
+
+
 def render_floor_machine_layout_with_customizable_names() -> Any:
     """Return a layout for managing floors and machines with editing controls."""
 
@@ -360,6 +372,7 @@ def render_floor_machine_layout_enhanced_with_selection() -> Any:
 
 
 __all__ = [
+    "render_dashboard_wrapper",
     "render_new_dashboard",
     "render_main_dashboard",
     "render_floor_machine_layout_with_customizable_names",

--- a/run_dashboard.py
+++ b/run_dashboard.py
@@ -25,7 +25,7 @@ from dashboard import (
     load_layout,
     initialize_data_saving,
 )
-from dashboard.layout import render_new_dashboard
+from dashboard.layout import render_dashboard_wrapper
 from dashboard.state import app_state
 
 logger = logging.getLogger(__name__)
@@ -132,7 +132,7 @@ if __name__ == "__main__":
 
             threading.Thread(target=open_browser).start()
 
-        app.layout = render_new_dashboard()
+        app.layout = render_dashboard_wrapper()
 
         app.run(debug=args.debug, use_reloader=False, host="0.0.0.0", port=8050)
 


### PR DESCRIPTION
## Summary
- wrap dashboards in new layout container and expose function
- switch run_dashboard to use the wrapper
- provide callbacks for toggling dashboards

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685decefc4fc8327995bff51ba22dbde