### PR TITLE
Enable floor/machine layout dashboard

### DIFF
--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -44,6 +44,7 @@ from .settings import (
     capacity_unit_label,
 )
 from .layout import (
+    render_dashboard_shell,
     render_new_dashboard,
     render_floor_machine_layout_with_customizable_names,
     render_floor_machine_layout_enhanced_with_selection,
@@ -84,6 +85,7 @@ __all__ = [
     "convert_capacity_from_lbs",
     "capacity_unit_label",
     "load_saved_image",
+    "render_dashboard_shell",
     "render_new_dashboard",
     "render_floor_machine_layout_with_customizable_names",
     "render_floor_machine_layout_enhanced_with_selection",

--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -54,6 +54,48 @@ SECTION_HEIGHT2 = "250px"
 HEADER_CARD_HEIGHT = "65px"
 
 
+def render_dashboard_shell() -> Any:
+    """Return the root layout with a dashboard switcher."""
+
+    floors_data, machines_data = load_layout()
+    if not floors_data:
+        floors_data = {"floors": [{"id": 1, "name": "1st Floor"}], "selected_floor": "all"}
+    if not machines_data:
+        machines_data = {"machines": [], "next_machine_id": 1}
+
+    return html.Div(
+        [
+            dcc.Store(id="current-dashboard", data="main"),
+            dcc.Store(id="floors-data", data=floors_data),
+            dcc.Store(id="machines-data", data=machines_data),
+            dcc.Store(id="active-machine-store", data={"machine_id": None}),
+            dbc.Row(
+                [
+                    dbc.Col(
+                        html.H4("Dashboard", className="m-2"),
+                        width="auto",
+                    ),
+                    dbc.Col(
+                        dcc.Dropdown(
+                            id="dashboard-selector",
+                            options=[
+                                {"label": "Main", "value": "main"},
+                                {"label": "Layout", "value": "layout"},
+                            ],
+                            value="main",
+                            clearable=False,
+                            className="w-100",
+                        ),
+                        width=2,
+                    ),
+                ],
+                className="g-2 align-items-center mb-2",
+            ),
+            html.Div(id="dashboard-content"),
+        ]
+    )
+
+
 def render_new_dashboard() -> Any:
     """Return the main dashboard layout filled with visible sections."""
     grid = render_main_dashboard()
@@ -360,6 +402,7 @@ def render_floor_machine_layout_enhanced_with_selection() -> Any:
 
 
 __all__ = [
+    "render_dashboard_shell",
     "render_new_dashboard",
     "render_main_dashboard",
     "render_floor_machine_layout_with_customizable_names",

--- a/run_dashboard.py
+++ b/run_dashboard.py
@@ -25,7 +25,7 @@ from dashboard import (
     load_layout,
     initialize_data_saving,
 )
-from dashboard.layout import render_new_dashboard
+from dashboard.layout import render_dashboard_shell
 from dashboard.state import app_state
 
 logger = logging.getLogger(__name__)
@@ -132,7 +132,7 @@ if __name__ == "__main__":
 
             threading.Thread(target=open_browser).start()
 
-        app.layout = render_new_dashboard()
+        app.layout = render_dashboard_shell()
 
         app.run(debug=args.debug, use_reloader=False, host="0.0.0.0", port=8050)
 

--- a/tests/test_dashboard_utils.py
+++ b/tests/test_dashboard_utils.py
@@ -189,6 +189,7 @@ def test_layout_functions_return_components(monkeypatch):
 
 
     for func in [
+        layout.render_dashboard_shell,
         layout.render_new_dashboard,
         layout.render_floor_machine_layout_with_customizable_names,
         layout.render_floor_machine_layout_enhanced_with_selection,


### PR DESCRIPTION
## Summary
- add main dashboard switcher with layout option
- connect floor and machine management callbacks
- export new layout helper
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685decf283648327b6138f997cae1068