### PR TITLE
Fix dynamic dashboard card heights

### DIFF
--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -53,6 +53,12 @@ SECTION_HEIGHT = "220px"
 SECTION_HEIGHT2 = "250px"
 HEADER_CARD_HEIGHT = "65px"
 
+# The taller cards span two standard section heights plus the vertical margin
+# between them.  Derive these values from the base constants so any adjustments
+# remain consistent with the overall grid layout.
+ROW1_TALL_HEIGHT = f"{2 * int(SECTION_HEIGHT[:-2]) + 9}px"
+ROW2_TALL_HEIGHT = f"{2 * int(SECTION_HEIGHT2[:-2]) + 8}px"
+
 
 def render_new_dashboard() -> Any:
     """Return the main dashboard layout filled with visible sections."""
@@ -103,7 +109,7 @@ def render_main_dashboard() -> Any:
                 [
                     dbc.Card(
                         dbc.CardBody(id="section-2", className="p-2"),
-                        style={"height": "449px"},
+                        style={"height": ROW1_TALL_HEIGHT},
                     )
                 ],
                 width=3,
@@ -134,7 +140,7 @@ def render_main_dashboard() -> Any:
                     dbc.Card(
                         dbc.CardBody(id="section-4", className="p-2"),
                         className="mb-2",
-                        style={"height": "508px"},
+                        style={"height": ROW2_TALL_HEIGHT},
                     ),
                 ],
                 width=2,


### PR DESCRIPTION
## Summary
- compute tall card dimensions from `SECTION_HEIGHT` values
- update `render_main_dashboard` to use the new derived constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685decf65c2c832793a73e592350dbd2