### PR TITLE
Fix duplicate dash callback registration

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -347,7 +347,7 @@ def register_callbacks() -> None:
     @_dash_callback(
         Output("current-dashboard", "data", allow_duplicate=True),
         Input("dashboard-selector", "value"),
-        prevent_initial_call=False,
+        prevent_initial_call=True,
     )
     def switch_dashboard(value):
         """Switch between dashboard views."""


### PR DESCRIPTION
## Summary
- adjust switch_dashboard callback to comply with Dash's duplicate output rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685df0bf0fac8327a44eec7d3bc30b6d