### PR TITLE
Add settings modal and header

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -543,6 +543,23 @@ def register_callbacks() -> None:
         return {"content": csv_data, "filename": f"satake_data_export_{timestamp}.csv"}
 
     @_dash_callback(
+        Output("settings-modal", "is_open"),
+        [Input("settings-button", "n_clicks"), Input("close-settings", "n_clicks")],
+        [State("settings-modal", "is_open")],
+        prevent_initial_call=True,
+    )
+    def toggle_settings_modal(open_clicks, close_clicks, is_open):
+        ctx = callback_context
+        if not ctx.triggered:
+            return no_update
+        trigger = ctx.triggered[0]["prop_id"].split(".")[0]
+        if trigger == "settings-button" and open_clicks:
+            return not is_open
+        if trigger == "close-settings" and close_clicks:
+            return False
+        return is_open
+
+    @_dash_callback(
         Output("section-1-2", "children"),
         Input("status-update-interval", "n_intervals"),
         State("production-data-store", "data"),

--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -5,6 +5,7 @@ from typing import Any
 from .machine_layout import load_layout
 
 from .settings import load_language_preference, load_weight_preference
+from i18n import tr
 from .images import load_saved_image
 
 # ``dash`` is an optional dependency during testing.  These helpers fall
@@ -70,12 +71,29 @@ def render_dashboard_shell() -> Any:
     if not machines_data:
         machines_data = {"machines": [], "next_machine_id": 1}
 
+    header = html.Div(
+        [
+            html.H3(id="dashboard-title", children=tr("dashboard_title"), className="m-0"),
+            html.Div(
+                [
+                    dbc.Button(tr("switch_dashboards"), id="new-dashboard-btn", color="light", size="sm", className="me-2"),
+                    dbc.Button(tr("generate_report"), id="generate-report-btn", color="light", size="sm", className="me-2"),
+                    dbc.Button(html.I(className="fas fa-cog"), id="settings-button", color="secondary", size="sm"),
+                    dcc.Download(id="report-download"),
+                ],
+                className="ms-auto d-flex align-items-center",
+            ),
+        ],
+        className="d-flex justify-content-between align-items-center bg-primary text-white p-2 mb-2",
+    )
+
     return html.Div(
         [
             dcc.Store(id="current-dashboard", data="main"),
             dcc.Store(id="floors-data", data=floors_data),
             dcc.Store(id="machines-data", data=machines_data),
             dcc.Store(id="active-machine-store", data={"machine_id": None}),
+            header,
             dbc.Row(
                 [
                     dbc.Col(
@@ -99,6 +117,7 @@ def render_dashboard_shell() -> Any:
                 className="g-2 align-items-center mb-2",
             ),
             html.Div(id="dashboard-content"),
+            settings_modal,
         ]
     )
 
@@ -424,10 +443,34 @@ def render_floor_machine_layout_enhanced_with_selection() -> Any:
     return render_floor_machine_layout_with_customizable_names()
 
 
+# Simplified settings modal used for configuration
+settings_modal = dbc.Modal(
+    [
+        dbc.ModalHeader(html.Span(tr("system_settings_title"), id="settings-modal-header")),
+        dbc.ModalBody(
+            dbc.Tabs(
+                [
+                    dbc.Tab(html.Div("Display settings"), label="Display"),
+                    dbc.Tab(html.Div("System settings"), label="System"),
+                    dbc.Tab(html.Div("Email setup"), label="Email Setup"),
+                ]
+            )
+        ),
+        dbc.ModalFooter(
+            dbc.Button(tr("close"), id="close-settings", color="secondary")
+        ),
+    ],
+    id="settings-modal",
+    size="lg",
+    is_open=False,
+)
+
+
 __all__ = [
     "render_dashboard_wrapper",
     "render_new_dashboard",
     "render_main_dashboard",
     "render_floor_machine_layout_with_customizable_names",
     "render_floor_machine_layout_enhanced_with_selection",
+    "settings_modal",
 ]

--- a/tests/test_dashboard_utils.py
+++ b/tests/test_dashboard_utils.py
@@ -217,6 +217,25 @@ def test_render_new_dashboard_has_weight_store(monkeypatch):
     assert find_weight_store(comp)
 
 
+def test_dashboard_shell_contains_header_and_modal(monkeypatch):
+    _, _, _, layout, _ = load_modules(monkeypatch)
+    comp = layout.render_dashboard_shell()
+
+    def find_by_id(node, target):
+        if getattr(node, "props", {}).get("id") == target:
+            return True
+        children = getattr(node, "children", []) or []
+        if len(children) == 1 and isinstance(children[0], list):
+            children = children[0]
+        for child in children:
+            if find_by_id(child, target):
+                return True
+        return False
+
+    assert find_by_id(comp, "dashboard-title")
+    assert find_by_id(comp, "settings-modal")
+
+
 def test_reconnection_helpers_execute(monkeypatch):
     calls = {}
 


### PR DESCRIPTION
## Summary
- add header, settings button, and download component to dashboard shell
- create a simplified `settings_modal` with basic tabs
- expose modal toggle callback
- check for modal and header in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685df84c9bd48327b3e366b03bd3e7ae