### PR TITLE
Switch to shell layout

### DIFF
--- a/run_dashboard.py
+++ b/run_dashboard.py
@@ -26,7 +26,7 @@ from dashboard import (
     initialize_data_saving,
 )
 
-from dashboard.layout import render_dashboard_wrapper
+from dashboard.layout import render_dashboard_shell
 from dashboard.state import app_state
 
 logger = logging.getLogger(__name__)
@@ -134,7 +134,7 @@ if __name__ == "__main__":
             threading.Thread(target=open_browser).start()
 
 
-        app.layout = render_dashboard_wrapper()
+        app.layout = render_dashboard_shell()
         app.run(debug=args.debug, use_reloader=False, host="0.0.0.0", port=8050)
 
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
- use `render_dashboard_shell` instead of `render_dashboard_wrapper`

## Testing
- `pytest -q`
- `python run_dashboard.py --no-open-browser --debug` *(fails: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_685dfb10c7288327a068364deef4fee8