### PR TITLE
Insert connection controls card

### DIFF
--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -94,6 +94,7 @@ def render_dashboard_shell() -> Any:
             dcc.Store(id="machines-data", data=machines_data),
             dcc.Store(id="active-machine-store", data={"machine_id": None}),
             header,
+            connection_controls,
             dbc.Row(
                 [
                     dbc.Col(


### PR DESCRIPTION
## Summary
- expose legacy connection_controls card in dashboard shell

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dfc53c80c83278b5f9508fa5453bb