### PR TITLE
Update header settings button ID

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -544,16 +544,22 @@ def register_callbacks() -> None:
 
     @_dash_callback(
         Output("settings-modal", "is_open"),
-        [Input("settings-button", "n_clicks"), Input("close-settings", "n_clicks")],
+        [
+            Input("settings-button", "n_clicks"),
+            Input("header-settings-button", "n_clicks"),
+            Input("close-settings", "n_clicks"),
+        ],
         [State("settings-modal", "is_open")],
         prevent_initial_call=True,
     )
-    def toggle_settings_modal(open_clicks, close_clicks, is_open):
+    def toggle_settings_modal(side_clicks, header_clicks, close_clicks, is_open):
         ctx = callback_context
         if not ctx.triggered:
             return no_update
         trigger = ctx.triggered[0]["prop_id"].split(".")[0]
-        if trigger == "settings-button" and open_clicks:
+        if trigger in ("settings-button", "header-settings-button") and (
+            side_clicks or header_clicks
+        ):
             return not is_open
         if trigger == "close-settings" and close_clicks:
             return False

--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -78,7 +78,8 @@ def render_dashboard_shell() -> Any:
                 [
                     dbc.Button(tr("switch_dashboards"), id="new-dashboard-btn", color="light", size="sm", className="me-2"),
                     dbc.Button(tr("generate_report"), id="generate-report-btn", color="light", size="sm", className="me-2"),
-                    dbc.Button(html.I(className="fas fa-cog"), id="settings-button", color="secondary", size="sm"),
+                    # settings button in the header opens the configuration modal
+                    dbc.Button(html.I(className="fas fa-cog"), id="header-settings-button", color="secondary", size="sm"),
                     dcc.Download(id="report-download"),
                 ],
                 className="ms-auto d-flex align-items-center",


### PR DESCRIPTION
## Summary
- rename header `settings-button` to `header-settings-button`
- toggle settings modal from either settings button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dfdfb4d388327b98e2178bdf7f4ce