### PR TITLE
Remove unused dashboard dropdown

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -347,16 +347,6 @@ def register_callbacks() -> None:
         return no_update, no_update
 
     @_dash_callback(
-        Output("current-dashboard", "data", allow_duplicate=True),
-        Input("dashboard-selector", "value"),
-        prevent_initial_call=True,
-    )
-    def switch_dashboard(value):
-        """Switch between dashboard views."""
-        return value or "main"
-
-
-    @_dash_callback(
         Output("machines-container", "children"),
         Input("floors-data", "data"),
         Input("machines-data", "data"),

--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -90,34 +90,12 @@ def render_dashboard_shell() -> Any:
 
     return html.Div(
         [
-            dcc.Store(id="current-dashboard", data="main"),
+            dcc.Store(id="current-dashboard", data="new"),
             dcc.Store(id="floors-data", data=floors_data),
             dcc.Store(id="machines-data", data=machines_data),
             dcc.Store(id="active-machine-store", data={"machine_id": None}),
             header,
             connection_controls,
-            dbc.Row(
-                [
-                    dbc.Col(
-                        html.H4("Dashboard", className="m-2"),
-                        width="auto",
-                    ),
-                    dbc.Col(
-                        dcc.Dropdown(
-                            id="dashboard-selector",
-                            options=[
-                                {"label": "Main", "value": "main"},
-                                {"label": "Layout", "value": "layout"},
-                            ],
-                            value="main",
-                            clearable=False,
-                            className="w-100",
-                        ),
-                        width=2,
-                    ),
-                ],
-                className="g-2 align-items-center mb-2",
-            ),
             html.Div(id="dashboard-content"),
             settings_modal,
         ]

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -66,3 +66,12 @@ def test_section_callbacks_exist(monkeypatch):
         result = func(*args)
         comp = result[0] if isinstance(result, tuple) else result
         assert comp is not None
+
+
+def test_manage_dashboard_toggle(monkeypatch):
+    callbacks, registered = load_callbacks(monkeypatch)
+    manage = registered["manage_dashboard"]
+
+    assert manage(None, "new") == "new"
+    assert manage(1, "new") == "main"
+    assert manage(2, "main") == "new"


### PR DESCRIPTION
## Summary
- drop the dashboard selector row
- remove callback tied to `dashboard-selector`
- default dashboard to "new" as in legacy code
- test the button-based dashboard toggle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dffb358bc832791c660f5030249b1