### PR TITLE
Update manage_dashboard output to allow duplicates

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -147,7 +147,7 @@ def register_callbacks() -> None:
         return render_main_dashboard()
 
     @_dash_callback(
-        Output("current-dashboard", "data"),
+        Output("current-dashboard", "data", allow_duplicate=True),
         Input("new-dashboard-btn", "n_clicks"),
         State("current-dashboard", "data"),
         prevent_initial_call=False,


### PR DESCRIPTION
## Summary
- update the `manage_dashboard` callback decorator to allow duplicate updates to
  `current-dashboard`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e01a7599c8327af2d620a6b4eb888