### PR TITLE
Fix manage_dashboard callback compatibility

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -150,7 +150,7 @@ def register_callbacks() -> None:
         Output("current-dashboard", "data", allow_duplicate=True),
         Input("new-dashboard-btn", "n_clicks"),
         State("current-dashboard", "data"),
-        prevent_initial_call=False,
+        prevent_initial_call="initial_duplicate",
     )
     def manage_dashboard(n_clicks, current):
         if n_clicks is None:


### PR DESCRIPTION
## Summary
- update manage_dashboard callback to set `prevent_initial_call="initial_duplicate"`

## Testing
- `pytest -q`
- `python - <<'EOF'
import dashboard.app
try:
    import dashboard.callbacks
    print('callbacks imported')
except Exception as e:
    print('error:', type(e).__name__, e)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685e030e51408327b8c94f7661c7976b