### PR TITLE
Move preference stores

### DIFF
--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -94,6 +94,11 @@ def render_dashboard_shell() -> Any:
             dcc.Store(id="floors-data", data=floors_data),
             dcc.Store(id="machines-data", data=machines_data),
             dcc.Store(id="active-machine-store", data={"machine_id": None}),
+            dcc.Interval(id="status-update-interval", interval=1000, n_intervals=0),
+            dcc.Store(id="production-data-store"),
+            dcc.Store(id="weight-preference-store", data=load_weight_preference()),
+            dcc.Store(id="language-preference-store", data=load_language_preference()),
+            dcc.Store(id="additional-image-store", data=load_saved_image()),
             header,
             connection_controls,
             html.Div(id="dashboard-content"),
@@ -108,24 +113,6 @@ def render_new_dashboard() -> Any:
 
     return html.Div(
         [
-            dcc.Interval(
-                id="status-update-interval",
-                interval=1000,
-                n_intervals=0,
-            ),
-            dcc.Store(id="production-data-store"),
-            dcc.Store(
-                id="weight-preference-store",
-                data=load_weight_preference(),
-            ),
-            dcc.Store(
-                id="language-preference-store",
-                data=load_language_preference(),
-            ),
-            dcc.Store(
-                id="additional-image-store",
-                data=load_saved_image(),
-            ),
             grid,
         ]
     )

--- a/tests/test_dashboard_utils.py
+++ b/tests/test_dashboard_utils.py
@@ -201,7 +201,7 @@ def test_layout_functions_return_components(monkeypatch):
 
 def test_render_new_dashboard_has_weight_store(monkeypatch):
     _, _, _, layout, _ = load_modules(monkeypatch)
-    comp = layout.render_new_dashboard()
+    comp = layout.render_dashboard_shell()
 
     def find_weight_store(node):
         if getattr(node, "props", {}).get("id") == "weight-preference-store":


### PR DESCRIPTION
## Summary
- inject preference stores and status interval at the dashboard shell level
- trim duplicated stores from new dashboard
- adjust tests to look for preference stores in `render_dashboard_shell`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e04fc60c48327a4b03fa89ad170a5