### PR TITLE
Add dashboard arg gate for production section

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -160,13 +160,16 @@ def register_callbacks() -> None:
     @_dash_callback(
         Output("section-1-1", "children"),
         Output("production-data-store", "data"),
+        Input("current-dashboard", "data"),
         Input("status-update-interval", "n_intervals"),
         State("production-data-store", "data"),
         State("weight-preference-store", "data"),
         State("language-preference-store", "data"),
     )
-    def update_production_section(n, production_data, weight_pref, lang):
+    def update_production_section(which, n, production_data, weight_pref, lang):
         """Update capacity display using latest OPC tag values."""
+        if which not in ("new", "main"):
+            return no_update, no_update
         pref = weight_pref or {"unit": "lb", "label": "lbs", "value": 1.0}
         lang = lang or "en"
 


### PR DESCRIPTION
## Summary
- allow update_production_section to skip when not on new or main dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e06897a98832782b56bd988bca09a