### PR TITLE
Add hidden divs for section IDs

### DIFF
--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -400,7 +400,26 @@ def render_floor_machine_layout_with_customizable_names() -> Any:
 
     main = dbc.Col(html.Div(right_content), width=9)
 
-    return dbc.Row([sidebar, main])
+    layout_row = dbc.Row([sidebar, main])
+
+    hidden_sections = html.Div(
+        [
+            html.Div(id="section-1-1", children=[], style={"display": "none"}),
+            html.Div(id="section-1-2", children=[], style={"display": "none"}),
+            html.Div(id="section-2", children=[], style={"display": "none"}),
+            html.Div(id="section-3-1", children=[], style={"display": "none"}),
+            html.Div(id="section-3-2", children=[], style={"display": "none"}),
+            html.Div(id="section-4", children=[], style={"display": "none"}),
+            html.Div(id="section-5-1", children=[], style={"display": "none"}),
+            html.Div(id="section-5-2", children=[], style={"display": "none"}),
+            html.Div(id="section-6-1", children=[], style={"display": "none"}),
+            html.Div(id="section-6-2", children=[], style={"display": "none"}),
+            html.Div(id="section-7-1", children=[], style={"display": "none"}),
+            html.Div(id="section-7-2", children=[], style={"display": "none"}),
+        ]
+    )
+
+    return html.Div([layout_row, hidden_sections])
 
 
 def render_floor_machine_layout_enhanced_with_selection() -> Any:

--- a/tests/test_dashboard_utils.py
+++ b/tests/test_dashboard_utils.py
@@ -272,3 +272,26 @@ def test_reconnection_helpers_execute(monkeypatch):
 
     assert calls["connect"] == "opc.tcp://example:4840"
 
+
+def test_floor_layout_has_hidden_sections(monkeypatch):
+    _, _, _, layout, _ = load_modules(monkeypatch)
+    comp = layout.render_floor_machine_layout_with_customizable_names()
+
+    ids = set()
+
+    def gather(node):
+        ident = getattr(node, "props", {}).get("id")
+        if isinstance(ident, dict):
+            ident = str(ident)
+        if ident:
+            ids.add(ident)
+        children = getattr(node, "children", []) or []
+        if len(children) == 1 and isinstance(children[0], list):
+            children = children[0]
+        for child in children:
+            gather(child)
+
+    gather(comp)
+
+    assert "section-1-1" in ids
+    assert "section-7-2" in ids


### PR DESCRIPTION
## Summary
- include invisible section placeholders in `render_floor_machine_layout_with_customizable_names`
- add regression test verifying hidden sections

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e077b30d4832793a3c4b09e5226be