### PR TITLE
Update manage_dashboard prevent_initial_call

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -150,7 +150,7 @@ def register_callbacks() -> None:
         Output("current-dashboard", "data", allow_duplicate=True),
         Input("new-dashboard-btn", "n_clicks"),
         State("current-dashboard", "data"),
-        prevent_initial_call="initial_duplicate",
+        prevent_initial_call=False,
     )
     def manage_dashboard(n_clicks, current):
         if n_clicks is None:


### PR DESCRIPTION
## Summary
- fix `prevent_initial_call` flag for `manage_dashboard` callback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e0c2b4acc83278b64efff6b057443