### PR TITLE
Fix dashboard manage callback initial call

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -150,7 +150,7 @@ def register_callbacks() -> None:
         Output("current-dashboard", "data", allow_duplicate=True),
         Input("new-dashboard-btn", "n_clicks"),
         State("current-dashboard", "data"),
-        prevent_initial_call=False,
+        prevent_initial_call=True,
     )
     def manage_dashboard(n_clicks, current):
         if n_clicks is None:


### PR DESCRIPTION
## Summary
- prevent the dashboard toggle callback from firing on load
- verify no other callbacks use `allow_duplicate=True` with `prevent_initial_call=False`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e0d8ec8788327908d73374e561ee3