### PR TITLE
Add floor machine layout callback

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -158,6 +158,46 @@ def register_callbacks() -> None:
         return "new" if current == "main" else "main"
 
     @_dash_callback(
+        Output("floor-machine-container", "children"),
+        Input("machines-data", "data"),
+        Input("floors-data", "data"),
+        Input("ip-addresses-store", "data"),
+        Input("additional-image-store", "data"),
+        Input("current-dashboard", "data"),
+        Input("active-machine-store", "data"),
+        Input("app-mode", "data"),
+        Input("language-preference-store", "data"),
+        prevent_initial_call=True,
+    )
+    def render_floor_machine_layout_cb(
+        machines_data,
+        floors_data,
+        ip_addrs,
+        image_data,
+        dashboard,
+        active_machine,
+        app_mode_data,
+        lang,
+    ):
+        """Render the floor/machine management layout when on the new dashboard."""
+        if dashboard != "new":
+            if HAS_DASH:
+                from dash.exceptions import PreventUpdate
+                raise PreventUpdate
+            return no_update
+
+        ctx = callback_context
+        if ctx.triggered:
+            trigger_id = ctx.triggered[0]["prop_id"]
+            if "machines-data" in trigger_id:
+                floors = floors_data.get("floors", []) if isinstance(floors_data, dict) else []
+                for floor in floors:
+                    if floor.get("editing"):
+                        return no_update
+
+        return render_floor_machine_layout_with_customizable_names()
+
+    @_dash_callback(
         Output("section-1-1", "children"),
         Output("production-data-store", "data"),
         Input("current-dashboard", "data"),

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -75,3 +75,11 @@ def test_manage_dashboard_toggle(monkeypatch):
     assert manage(None, "new") == "new"
     assert manage(1, "new") == "main"
     assert manage(2, "main") == "new"
+
+
+def test_floor_machine_container_populated(monkeypatch):
+    callbacks, registered = load_callbacks(monkeypatch)
+    render = registered["render_floor_machine_layout_cb"]
+
+    comp = render({}, {}, {}, {}, "new", {}, None, "en")
+    assert hasattr(comp, "children")


### PR DESCRIPTION
## Summary
- implement callback to render floor machine layout
- test callback output for new dashboard view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e127c6f748327be45cb54edc7c385