### PR TITLE
Add image persistence helper

### DIFF
--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -14,7 +14,7 @@ from .opc_client import (
     resume_update_thread,
 )
 from .startup import start_auto_reconnection, delayed_startup_connect
-from .images import load_saved_image
+from .images import load_saved_image, save_uploaded_image
 from .machine_layout import save_layout, load_layout
 from .data_export import (
     initialize_data_saving,
@@ -87,6 +87,7 @@ __all__ = [
     "convert_capacity_from_lbs",
     "capacity_unit_label",
     "load_saved_image",
+    "save_uploaded_image",
     "render_dashboard_wrapper",
     "render_new_dashboard",
     "render_floor_machine_layout_with_customizable_names",

--- a/dashboard/images.py
+++ b/dashboard/images.py
@@ -1,5 +1,27 @@
 """Image helper functions for the dashboard."""
 
+import logging
+from pathlib import Path
+
 from .reconnection import load_saved_image
 
-__all__ = ["load_saved_image"]
+logger = logging.getLogger(__name__)
+
+DATA_PATH = Path(__file__).resolve().parents[1] / "data" / "custom_image.txt"
+
+
+def save_uploaded_image(image_data: str) -> bool:
+    """Persist ``image_data`` to :mod:`data/custom_image.txt`."""
+
+    try:
+        DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(DATA_PATH, "w") as fh:
+            fh.write(image_data)
+        logger.info("Custom image saved successfully")
+        return True
+    except Exception as exc:  # pragma: no cover - rely on filesystem
+        logger.error("Error saving custom image: %s", exc)
+        return False
+
+
+__all__ = ["load_saved_image", "save_uploaded_image"]


### PR DESCRIPTION
## Summary
- implement `save_uploaded_image` helper and include in module exports
- re-export new helper via `dashboard.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e16d548b08327af372f0214c057d2