### PR TITLE
Add threshold email tracking

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -8,6 +8,9 @@ from datetime import datetime
 from pathlib import Path
 import base64
 import tempfile
+import smtplib
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
 import generate_report
 
 # ``dash`` is optional during testing so fall back to light stubs when missing.
@@ -86,12 +89,12 @@ from .settings import (
     convert_capacity_from_kg,
     capacity_unit_label,
     load_threshold_settings,
+    load_email_settings,
 )
 from .layout import (
     render_new_dashboard,
     render_floor_machine_layout_with_customizable_names,
 )
-from .email_utils import send_threshold_email
 from i18n import tr
 from .layout import render_new_dashboard, render_main_dashboard
 
@@ -107,6 +110,14 @@ threshold_settings = load_threshold_settings() or {}
 production_history: list[float] = []
 counter_history = {i: [] for i in range(1, 13)}
 last_email_times = {i: None for i in range(1, 13)}
+threshold_violation_state = {
+    i: {
+        "is_violating": False,
+        "violation_start_time": None,
+        "email_sent": False,
+    }
+    for i in range(1, 13)
+}
 
 
 def _save_floor_machine_data(floors_data: dict, machines_data: dict) -> bool:
@@ -135,6 +146,51 @@ def _generate_csv_string(tags: dict) -> str:
         ts = getattr(data, "timestamps", [datetime.now()])[-1]
         writer.writerow([name, value, ts])
     return buf.getvalue()
+
+
+def send_threshold_email(sensitivity_num: int, is_high: bool = True) -> bool:
+    """Send an email notification for a threshold violation."""
+    try:
+        email_address = threshold_settings.get("email_address", "")
+        if not email_address:
+            logger.warning("No email address configured for notifications")
+            return False
+
+        msg = MIMEMultipart()
+        msg["Subject"] = "Enpresor Alarm"
+        msg["From"] = "jcantu@satake-usa.com"
+        msg["To"] = email_address
+
+        threshold_type = "upper" if is_high else "lower"
+        body = (
+            f"Sensitivity {sensitivity_num} has reached the {threshold_type} threshold."
+        )
+        msg.attach(MIMEText(body, "plain"))
+
+        logger.info(f"Sending email to {email_address}: {body}")
+
+        email_settings = load_email_settings()
+        server_addr = email_settings.get(
+            "smtp_server", DEFAULT_EMAIL_SETTINGS["smtp_server"]
+        )
+        port = email_settings.get("smtp_port", DEFAULT_EMAIL_SETTINGS["smtp_port"])
+        server = smtplib.SMTP(server_addr, port)
+        server.starttls()
+        username = email_settings.get("smtp_username")
+        password = email_settings.get("smtp_password")
+        if username and password:
+            server.login(username, password)
+
+        from_addr = email_settings.get(
+            "from_address", DEFAULT_EMAIL_SETTINGS["from_address"]
+        )
+        text = msg.as_string()
+        server.sendmail(from_addr, email_address, text)
+        server.quit()
+        return True
+    except Exception as e:  # pragma: no cover - just log
+        logger.error(f"Error sending threshold email: {e}")
+        return False
 
 
 def register_callbacks() -> None:
@@ -1021,20 +1077,34 @@ def register_callbacks() -> None:
             email_minutes = threshold_settings.get("email_minutes", 2)
             for i, val in enumerate(values, 1):
                 settings = threshold_settings.get(i, {})
+                violation = False
+                is_high = False
                 if settings.get("min_enabled") and val < settings.get("min_value", 0):
                     active_alarms.append(f"Sens. {i} below min")
-                    if email_enabled:
-                        last = last_email_times.get(i)
-                        if last is None or (now - last).total_seconds() >= email_minutes * 60:
-                            if send_threshold_email(i, is_high=False):
-                                last_email_times[i] = now
-                if settings.get("max_enabled") and val > settings.get("max_value", 0):
+                    violation = True
+                elif settings.get("max_enabled") and val > settings.get("max_value", 0):
                     active_alarms.append(f"Sens. {i} above max")
-                    if email_enabled:
-                        last = last_email_times.get(i)
-                        if last is None or (now - last).total_seconds() >= email_minutes * 60:
-                            if send_threshold_email(i, is_high=True):
-                                last_email_times[i] = now
+                    violation = True
+                    is_high = True
+
+                state = threshold_violation_state[i]
+                if email_enabled:
+                    if violation and not state["is_violating"]:
+                        state["is_violating"] = True
+                        state["violation_start_time"] = now
+                        state["email_sent"] = False
+                    elif violation and state["is_violating"]:
+                        if not state["email_sent"]:
+                            elapsed = (
+                                now - state["violation_start_time"]
+                            ).total_seconds()
+                            if elapsed >= email_minutes * 60:
+                                if send_threshold_email(i, is_high=is_high):
+                                    state["email_sent"] = True
+                    elif not violation and state["is_violating"]:
+                        state["is_violating"] = False
+                        state["violation_start_time"] = None
+                        state["email_sent"] = False
 
             fig = go.Figure(go.Bar(x=list(range(1, 13)), y=values))
             fig.update_layout(margin=dict(l=20, r=20, t=20, b=20), showlegend=False)

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -1,5 +1,9 @@
 
-"""User settings and preference helpers."""
+"""User settings and preference helpers.
+
+Includes helpers for threshold and email configuration used when
+triggering alarm notifications.
+"""
 
 import json
 import logging
@@ -12,6 +16,7 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 DISPLAY_SETTINGS_PATH = ROOT_DIR / "display_settings.json"
 IP_ADDRESSES_PATH = ROOT_DIR / "ip_addresses.json"
 EMAIL_SETTINGS_PATH = ROOT_DIR / "email_settings.json"
+# Contains per-sensitivity limits along with email threshold preferences
 THRESHOLD_SETTINGS_PATH = ROOT_DIR / "threshold_settings.json"
 
 DEFAULT_EMAIL_SETTINGS = {
@@ -288,7 +293,13 @@ def save_email_settings(settings: dict, path: Path = EMAIL_SETTINGS_PATH) -> boo
 
 
 def load_threshold_settings(path: Path = THRESHOLD_SETTINGS_PATH):
-    """Load threshold settings from ``path``."""
+    """Load threshold settings from ``path``.
+
+    The returned dictionary includes per-sensitivity limits as well as
+    email alert fields ``email_enabled``,
+    ``email_address`` and ``email_minutes`` controlling when threshold
+    notifications are sent.
+    """
     try:
         if path.exists():
             with open(path, "r") as f:


### PR DESCRIPTION
## Summary
- implement `send_threshold_email` inside `callbacks`
- track ongoing threshold violations
- trigger alert emails once violation persists
- document threshold email options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1876f5748327b1d80f9be93326fa