### PR TITLE
Enable report downloads from UI

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -648,6 +648,8 @@ def register_callbacks() -> None:
             "base64": True,
         }
 
+    globals()["generate_report_callback"] = generate_report_callback
+
     @_dash_callback(
         Output("settings-modal", "is_open"),
         [
@@ -1101,4 +1103,7 @@ def register_callbacks() -> None:
 
 register_callbacks()
 
-__all__ = ["register_callbacks"]
+__all__ = [
+    "register_callbacks",
+    "generate_report_callback",
+]


### PR DESCRIPTION
## Summary
- expose `generate_report_callback` for easier import
- include new callback in module exports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e18796a2883278e02c10a117d93fb