### PR TITLE
Add historical controls visibility callback

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -163,6 +163,17 @@ def register_callbacks() -> None:
         return "new" if current == "main" else "main"
 
     @_dash_callback(
+        Output("historical-time-controls", "className"),
+        Input("mode-selector", "value"),
+        prevent_initial_call=True,
+    )
+    def toggle_historical_controls_visibility(mode):
+        """Show or hide historical controls based on mode."""
+        if mode == "historical":
+            return "d-block"
+        return "d-none"
+
+    @_dash_callback(
         Output("floor-machine-container", "children"),
         Input("machines-data", "data"),
         Input("floors-data", "data"),

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -107,3 +107,11 @@ def test_delete_confirmation_callback_registered(monkeypatch):
     args = [None] * len(params)
     result = func(*args)
     assert result is not None
+
+
+def test_toggle_historical_controls(monkeypatch):
+    callbacks, registered = load_callbacks(monkeypatch)
+    func = registered.get("toggle_historical_controls_visibility")
+    assert func is not None
+    assert func("historical") == "d-block"
+    assert func("live") == "d-none"


### PR DESCRIPTION
## Summary
- add toggle_historical_controls_visibility callback
- test visibility toggling behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e187c610483278c6ecdd4cb6402e9