### PR TITLE
Add image upload modal

### DIFF
--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -109,6 +109,7 @@ def render_dashboard_shell() -> Any:
             connection_controls,
             html.Div(id="dashboard-content"),
             settings_modal,
+            upload_modal,
             delete_confirmation_modal,
         ]
     )
@@ -637,6 +638,42 @@ settings_modal = dbc.Modal(
 )
 
 
+# Modal for uploading a custom image
+upload_modal = dbc.Modal(
+    [
+        dbc.ModalHeader(html.Span(tr("upload_image_title"), id="upload-modal-header")),
+        dbc.ModalBody(
+            [
+                dcc.Upload(
+                    id="upload-image",
+                    children=html.Div([
+                        tr("drag_and_drop"),
+                        html.A(tr("select_image")),
+                    ]),
+                    style={
+                        "width": "100%",
+                        "height": "60px",
+                        "lineHeight": "60px",
+                        "borderWidth": "1px",
+                        "borderStyle": "dashed",
+                        "borderRadius": "5px",
+                        "textAlign": "center",
+                        "margin": "10px",
+                    },
+                    multiple=False,
+                ),
+                html.Div(id="upload-status"),
+            ]
+        ),
+        dbc.ModalFooter(
+            [dbc.Button(tr("close"), id="close-upload-modal", color="secondary")]
+        ),
+    ],
+    id="upload-modal",
+    is_open=False,
+)
+
+
 # Confirmation modal displayed before deleting a floor or machine
 delete_confirmation_modal = dbc.Modal(
     [
@@ -670,5 +707,6 @@ __all__ = [
     "render_floor_machine_layout_enhanced_with_selection",
     "connection_controls",
     "settings_modal",
+    "upload_modal",
     "delete_confirmation_modal",
 ]

--- a/dashboard/reconnection.py
+++ b/dashboard/reconnection.py
@@ -114,8 +114,24 @@ def load_saved_image():
         logger.error("Error loading custom image: %s", exc)
         return {}
 
+
+def save_uploaded_image(image_data: str) -> bool:
+    """Persist ``image_data`` to :mod:`data/custom_image.txt`."""
+
+    path = Path(__file__).resolve().parents[1] / "data" / "custom_image.txt"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as fh:
+            fh.write(image_data)
+        logger.info("Custom image saved successfully")
+        return True
+    except Exception as exc:  # pragma: no cover - rely on filesystem
+        logger.error("Error saving custom image: %s", exc)
+        return False
+
 __all__ = [
     "start_auto_reconnection",
     "delayed_startup_connect",
     "load_saved_image",
+    "save_uploaded_image",
 ]


### PR DESCRIPTION
## Summary
- add `save_uploaded_image` helper to reconnection module
- support uploading a custom logo image in callbacks
- include upload modal and store results in layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e187b55d483278dfa3d6f161f3dc4