### PR TITLE
Add threshold settings modal

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -8,7 +8,10 @@ from datetime import datetime
 from pathlib import Path
 import base64
 import tempfile
-import generate_report
+try:
+    import generate_report
+except Exception:  # pragma: no cover - missing dependency
+    generate_report = None  # type: ignore
 
 # ``dash`` is optional during testing so fall back to light stubs when missing.
 try:  # pragma: no cover - optional dependency
@@ -86,6 +89,7 @@ from .settings import (
     convert_capacity_from_kg,
     capacity_unit_label,
     load_threshold_settings,
+    save_threshold_settings,
 )
 from .layout import (
     render_new_dashboard,
@@ -632,6 +636,8 @@ def register_callbacks() -> None:
 
         if not n_clicks:
             raise PreventUpdate
+        if generate_report is None:
+            raise PreventUpdate
 
         data = generate_report.fetch_last_24h_metrics()
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
@@ -668,6 +674,61 @@ def register_callbacks() -> None:
         ):
             return not is_open
         if trigger == "close-settings" and close_clicks:
+            return False
+        return is_open
+
+    @_dash_callback(
+        Output("threshold-modal", "is_open"),
+        [
+            Input({"type": "open-threshold", "index": ALL}, "n_clicks"),
+            Input("close-threshold-settings", "n_clicks"),
+            Input("save-threshold-settings", "n_clicks"),
+        ],
+        [
+            State("threshold-modal", "is_open"),
+            State({"type": "threshold-min-enabled", "index": ALL}, "value"),
+            State({"type": "threshold-max-enabled", "index": ALL}, "value"),
+            State({"type": "threshold-min-value", "index": ALL}, "value"),
+            State({"type": "threshold-max-value", "index": ALL}, "value"),
+            State("threshold-email-address", "value"),
+            State("threshold-email-minutes", "value"),
+            State("threshold-email-enabled", "value"),
+        ],
+        prevent_initial_call=True,
+    )
+    def toggle_threshold_modal(
+        open_clicks,
+        close_clicks,
+        save_clicks,
+        is_open,
+        min_enabled,
+        max_enabled,
+        min_values,
+        max_values,
+        email_address,
+        email_minutes,
+        email_enabled,
+    ):
+        ctx = callback_context
+        if not ctx.triggered:
+            return no_update
+        trigger = ctx.triggered[0]["prop_id"].split(".")[0]
+        if "open-threshold" in trigger and any(open_clicks):
+            return True
+        if trigger == "close-threshold-settings" and close_clicks:
+            return False
+        if trigger == "save-threshold-settings" and save_clicks:
+            for i in range(12):
+                threshold_settings[i + 1] = {
+                    "min_enabled": bool(min_enabled[i]),
+                    "max_enabled": bool(max_enabled[i]),
+                    "min_value": float(min_values[i] or 0),
+                    "max_value": float(max_values[i] or 0),
+                }
+            threshold_settings["email_enabled"] = bool(email_enabled)
+            threshold_settings["email_address"] = email_address or ""
+            threshold_settings["email_minutes"] = int(email_minutes or 2)
+            save_threshold_settings(threshold_settings)
             return False
         return is_open
 

--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -8,6 +8,7 @@ from .settings import (
     load_language_preference,
     load_weight_preference,
     load_ip_addresses,
+    load_threshold_settings,
 )
 from i18n import tr
 from .images import load_saved_image
@@ -108,6 +109,7 @@ def render_dashboard_shell() -> Any:
             header,
             connection_controls,
             html.Div(id="dashboard-content"),
+            threshold_modal,
             settings_modal,
             delete_confirmation_modal,
         ]
@@ -614,6 +616,130 @@ connection_controls = dbc.Card(
 )
 
 
+# Form for editing threshold settings
+def create_threshold_settings_form() -> list[Any]:
+    """Return rows of inputs for threshold alarm configuration."""
+    settings = load_threshold_settings() or {}
+    rows = []
+    for i in range(1, 13):
+        data = settings.get(i, {})
+        rows.append(
+            dbc.Row(
+                [
+                    dbc.Col(html.Div(f"Sensitivity {i}:", className="fw-bold"), width=2),
+                    dbc.Col(
+                        dbc.Input(
+                            id={"type": "threshold-min-value", "index": i},
+                            type="number",
+                            value=data.get("min_value", 0),
+                            min=0,
+                            max=180,
+                            step=1,
+                            size="sm",
+                        ),
+                        width=1,
+                    ),
+                    dbc.Col(
+                        dbc.Switch(
+                            id={"type": "threshold-min-enabled", "index": i},
+                            label="Min",
+                            value=data.get("min_enabled", False),
+                            className="medium",
+                        ),
+                        width=2,
+                    ),
+                    dbc.Col(
+                        dbc.Input(
+                            id={"type": "threshold-max-value", "index": i},
+                            type="number",
+                            value=data.get("max_value", 0),
+                            min=0,
+                            max=200,
+                            step=1,
+                            size="sm",
+                        ),
+                        width=1,
+                    ),
+                    dbc.Col(
+                        dbc.Switch(
+                            id={"type": "threshold-max-enabled", "index": i},
+                            label="Max",
+                            value=data.get("max_enabled", False),
+                            className="medium",
+                        ),
+                        width=2,
+                    ),
+                ],
+                className="mb-2",
+            )
+        )
+
+    rows.append(
+        dbc.Row(
+            [
+                dbc.Col(html.Div("Email Notifications:", className="fw-bold"), width=2),
+                dbc.Col(
+                    dbc.Input(
+                        id="threshold-email-address",
+                        type="email",
+                        placeholder="Email address",
+                        value=settings.get("email_address", ""),
+                        size="sm",
+                    ),
+                    width=3,
+                ),
+                dbc.Col(
+                    dbc.InputGroup(
+                        [
+                            dbc.Input(
+                                id="threshold-email-minutes",
+                                type="number",
+                                min=1,
+                                max=60,
+                                step=1,
+                                value=settings.get("email_minutes", 2),
+                                size="sm",
+                            ),
+                            dbc.InputGroupText("min", className="p-1 small"),
+                        ],
+                        size="sm",
+                    ),
+                    width=1,
+                ),
+                dbc.Col(
+                    dbc.Switch(
+                        id="threshold-email-enabled",
+                        value=settings.get("email_enabled", False),
+                        className="medium",
+                    ),
+                    width=2,
+                ),
+            ],
+            className="mt-3 mb-2",
+        )
+    )
+
+    return rows
+
+
+# Modal containing the threshold settings form
+threshold_modal = dbc.Modal(
+    [
+        dbc.ModalHeader(html.Span(tr("threshold_settings_title"), id="threshold-modal-header")),
+        dbc.ModalBody(html.Div(id="threshold-form-container", children=create_threshold_settings_form())),
+        dbc.ModalFooter(
+            [
+                dbc.Button(tr("close"), id="close-threshold-settings", color="secondary", className="me-2"),
+                dbc.Button(tr("save_changes"), id="save-threshold-settings", color="primary"),
+            ]
+        ),
+    ],
+    id="threshold-modal",
+    size="xl",
+    is_open=False,
+)
+
+
 # Simplified settings modal used for configuration
 settings_modal = dbc.Modal(
     [
@@ -669,6 +795,7 @@ __all__ = [
     "render_floor_machine_layout_with_customizable_names",
     "render_floor_machine_layout_enhanced_with_selection",
     "connection_controls",
+    "threshold_modal",
     "settings_modal",
     "delete_confirmation_modal",
 ]


### PR DESCRIPTION
## Summary
- implement `create_threshold_settings_form` in `dashboard/layout`
- expose new `threshold_modal` and load existing threshold values
- include the modal in the dashboard shell
- add callbacks for opening, closing and saving threshold settings
- guard optional generate_report import for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1877b850832781fc296fea3f4750