### PR TITLE
Enable floor layout init render

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -242,7 +242,6 @@ def register_callbacks() -> None:
         Input("active-machine-store", "data"),
         Input("app-mode", "data"),
         Input("language-preference-store", "data"),
-        prevent_initial_call=True,
     )
     def render_floor_machine_layout_cb(
         machines_data,


### PR DESCRIPTION
## Summary
- allow `render_floor_machine_layout_cb` to fire on page load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1bd42bbc8327b390c88c012bdbbd