### PR TITLE
Add app-mode store

### DIFF
--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -101,6 +101,8 @@ def render_dashboard_shell() -> Any:
             dcc.Store(id="active-machine-store", data={"machine_id": None}),
             dcc.Interval(id="status-update-interval", interval=1000, n_intervals=0),
             dcc.Store(id="production-data-store"),
+            dcc.Store(id="app-mode", data={"mode": "live"}),
+            dcc.Store(id="app-mode-tracker"),
             dcc.Store(id="ip-addresses-store", data=load_ip_addresses()),
             dcc.Store(id="weight-preference-store", data=load_weight_preference()),
             dcc.Store(id="language-preference-store", data=load_language_preference()),


### PR DESCRIPTION
## Summary
- add an `app-mode` store (and tracker) to the dashboard shell layout so callbacks receive the mode data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e1f4fd3188327821354175f4fa202