### PR TITLE
Ensure layout helpers include machine data store

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Run the dashboard application:
 python run_dashboard.py
 ```
 
+To embed the layout in another Dash app import `render_dashboard_shell` from
+the `dashboard` package and assign it to `app.layout`.
+
 Images used by the dashboard should be placed in an `assets/` directory that
 resides next to the script so Dash can serve them automatically.
 The provided `EnpresorMachine.png` image is included in this `assets/` folder.

--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -45,6 +45,7 @@ from .settings import (
 )
 from .layout import (
 
+    render_dashboard_shell,
     render_dashboard_wrapper,
 
     render_new_dashboard,
@@ -88,6 +89,7 @@ __all__ = [
     "capacity_unit_label",
     "load_saved_image",
     "save_uploaded_image",
+    "render_dashboard_shell",
     "render_dashboard_wrapper",
     "render_new_dashboard",
     "render_floor_machine_layout_with_customizable_names",

--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -122,8 +122,16 @@ def render_dashboard_shell() -> Any:
 def render_new_dashboard() -> Any:
     """Return the floor/machine management view."""
 
+    floors_data, machines_data = load_layout()
+    if not floors_data:
+        floors_data = {"floors": [{"id": 1, "name": "1st Floor"}], "selected_floor": "all"}
+    if not machines_data:
+        machines_data = {"machines": [], "next_machine_id": 1}
+
     return html.Div(
         [
+            dcc.Store(id="floors-data", data=floors_data),
+            dcc.Store(id="machines-data", data=machines_data),
             html.Div(id="floor-machine-container", className="px-4 pt-2 pb-4"),
             html.Div(
                 [
@@ -836,6 +844,7 @@ delete_confirmation_modal = dbc.Modal(
 
 
 __all__ = [
+    "render_dashboard_shell",
     "render_dashboard_wrapper",
     "render_new_dashboard",
     "render_main_dashboard",


### PR DESCRIPTION
## Summary
- supply floors and machines stores from `render_new_dashboard`
- expose `render_dashboard_shell` for embedding dashboards
- document `render_dashboard_shell` entry point in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e23512c1883278544f4eb40e82d59