### PR TITLE
Fix machine card rendering when adding on new dashboard

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -500,7 +500,7 @@ def register_callbacks() -> None:
         Input("current-dashboard", "data"),
     )
     def render_machine_cards(floors_data, machines_data, which):
-        if which != "layout":
+        if which != "new":
             return no_update
         selected = floors_data.get("selected_floor", "all")
         machines = machines_data.get("machines", [])

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -115,3 +115,21 @@ def test_toggle_historical_controls(monkeypatch):
     assert func is not None
     assert func("historical") == "d-block"
     assert func("live") == "d-none"
+
+
+def test_machine_cards_after_add(monkeypatch):
+    callbacks, registered = load_callbacks(monkeypatch)
+    add_machine = registered["add_machine_cb"]
+    render_cards = registered["render_machine_cards"]
+
+    monkeypatch.setattr(callbacks, "_save_floor_machine_data", lambda f, m: True)
+
+    floors = {"selected_floor": "all", "floors": [{"id": 1, "name": "F1"}]}
+    machines = {"machines": []}
+
+    machines = add_machine(1, machines, floors)
+    cards = render_cards(floors, machines, "new")
+
+    assert cards is not None
+    assert cards != callbacks.no_update
+    assert len(cards) == 1


### PR DESCRIPTION
## Summary
- update `render_machine_cards` to run on the "new" dashboard
- test machine card display after adding a machine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e2d9c23788327b7fb6f59bad571de