### PR TITLE
Show add-machine button only for specific floors

### DIFF
--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -463,8 +463,18 @@ def render_floor_machine_layout_with_customizable_names() -> Any:
             className="mb-1 machine-card-disconnected",
         ),
         html.Div(id="machines-container"),
-        dbc.Button("Add Machine", id="add-machine-btn", color="success", size="sm", className="mt-2"),
     ]
+
+    if selected_floor != "all":
+        right_content.append(
+            dbc.Button(
+                "Add Machine",
+                id="add-machine-btn",
+                color="success",
+                size="sm",
+                className="mt-2",
+            )
+        )
 
     main = dbc.Col(html.Div(right_content), width=9)
 

--- a/tests/test_add_machine_button.py
+++ b/tests/test_add_machine_button.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tests.test_dashboard_utils import load_modules
+
+
+def _find_by_id(node, target):
+    if getattr(node, "props", {}).get("id") == target:
+        return True
+    children = getattr(node, "children", []) or []
+    if len(children) == 1 and isinstance(children[0], list):
+        children = children[0]
+    for child in children:
+        if _find_by_id(child, target):
+            return True
+    return False
+
+
+def test_button_present_for_selected_floor(monkeypatch):
+    floors = {"floors": [{"id": 1, "name": "F1"}], "selected_floor": 1}
+    machines = {"machines": []}
+    _, _, _, layout, _ = load_modules(monkeypatch)
+    monkeypatch.setattr(layout, "load_layout", lambda: (floors, machines))
+    comp = layout.render_floor_machine_layout_with_customizable_names()
+    assert _find_by_id(comp, "add-machine-btn")
+
+
+def test_button_absent_for_all(monkeypatch):
+    floors = {"floors": [{"id": 1, "name": "F1"}], "selected_floor": "all"}
+    machines = {"machines": []}
+    _, _, _, layout, _ = load_modules(monkeypatch)
+    monkeypatch.setattr(layout, "load_layout", lambda: (floors, machines))
+    comp = layout.render_floor_machine_layout_with_customizable_names()
+    assert not _find_by_id(comp, "add-machine-btn")


### PR DESCRIPTION
## Summary
- conditionally render add machine button
- test new button visibility logic
- stub heavy dependencies in test helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e2fdfa15883278e887e00d48dd9c6