### PR TITLE
Update floor selection handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ ENV/
 
 # End of https://www.toptal.com/developers/gitignore/api/python
 exports/
+discovered_tags.txt

--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -344,14 +344,14 @@ def register_callbacks() -> None:
     def handle_floor_selection(clicks, ids, floors_data):
         """Switch the selected floor when a tile is clicked."""
         ctx = callback_context
-        if not ctx.triggered:
+        trigger = getattr(ctx, "triggered_id", None)
+        if not isinstance(trigger, dict) or trigger.get("type") != "floor-tile":
             return no_update
-        for i, c in enumerate(clicks):
-            if c and i < len(ids):
-                fid = ids[i]["index"]
-                floors_data["selected_floor"] = fid
-                return floors_data
-        return no_update
+        fid = trigger.get("index")
+        if fid is None:
+            return no_update
+        floors_data["selected_floor"] = fid
+        return floors_data
 
     @_dash_callback(
         Output("floors-data", "data", allow_duplicate=True),

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -133,3 +133,15 @@ def test_machine_cards_after_add(monkeypatch):
     assert cards is not None
     assert cards != callbacks.no_update
     assert len(cards) == 1
+
+
+def test_floor_selection_updates_selected(monkeypatch):
+    callbacks, registered = load_callbacks(monkeypatch)
+    select = registered["handle_floor_selection"]
+
+    for fid in [1, 2, 3]:
+        ctx = SimpleNamespace(triggered_id={"type": "floor-tile", "index": fid})
+        monkeypatch.setattr(callbacks, "callback_context", ctx)
+        data = {"selected_floor": "all"}
+        result = select([], [], data)
+        assert result["selected_floor"] == fid


### PR DESCRIPTION
## Summary
- update `handle_floor_selection` to rely on `callback_context.triggered_id`
- ignore `discovered_tags.txt`
- test that floor buttons update the selected floor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e2fe0dda48327b1d3659552e5da69