### PR TITLE
Improve floor selection handling

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -345,11 +345,32 @@ def register_callbacks() -> None:
         """Switch the selected floor when a tile is clicked."""
         ctx = callback_context
         trigger = getattr(ctx, "triggered_id", None)
-        if not isinstance(trigger, dict) or trigger.get("type") != "floor-tile":
-            return no_update
-        fid = trigger.get("index")
+
+        if trigger is None:
+            if not ctx.triggered:
+                return no_update
+            prop_id = ctx.triggered[0].get("prop_id")
+            if not prop_id or "floor-tile" not in prop_id:
+                return no_update
+            import json
+            import re
+
+            match = re.search(r"\{[^}]+\}", prop_id)
+            if not match:
+                return no_update
+            try:
+                btn_id = json.loads(match.group())
+                fid = btn_id.get("index")
+            except json.JSONDecodeError:
+                return no_update
+        else:
+            if not isinstance(trigger, dict) or trigger.get("type") != "floor-tile":
+                return no_update
+            fid = trigger.get("index")
+
         if fid is None:
             return no_update
+
         floors_data["selected_floor"] = fid
         return floors_data
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -145,3 +145,16 @@ def test_floor_selection_updates_selected(monkeypatch):
         data = {"selected_floor": "all"}
         result = select([], [], data)
         assert result["selected_floor"] == fid
+
+
+def test_floor_selection_fallback_to_triggered(monkeypatch):
+    callbacks, registered = load_callbacks(monkeypatch)
+    select = registered["handle_floor_selection"]
+
+    for fid in [1, 2, 3]:
+        prop = f'{{"type":"floor-tile","index":{fid}}}.n_clicks'
+        ctx = SimpleNamespace(triggered=[{"prop_id": prop}])
+        monkeypatch.setattr(callbacks, "callback_context", ctx)
+        data = {"selected_floor": "all"}
+        result = select([], [], data)
+        assert result["selected_floor"] == fid


### PR DESCRIPTION
## Summary
- support older Dash versions where `triggered_id` isn't defined
- parse the floor id from `callback_context.triggered` as a fallback
- exercise both code paths in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e9ddbbd3083278605133e03b40d82