### PR TITLE
Improve floor tile selection compatibility

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -347,10 +347,23 @@ def register_callbacks() -> None:
         ctx = callback_context
         trigger = getattr(ctx, "triggered_id", None)
 
-        if not isinstance(trigger, dict) or trigger.get("type") != "floor-tile":
-            return no_update
+        fid = None
+        if isinstance(trigger, dict) and trigger.get("type") == "floor-tile":
+            fid = trigger.get("index")
+        elif ctx.triggered:
+            prop = ctx.triggered[0]["prop_id"]
+            if "floor-tile" in prop:
+                import json
+                import re
 
-        fid = trigger.get("index")
+                match = re.search(r"\{[^}]+\}", prop)
+                if match:
+                    try:
+                        info = json.loads(match.group())
+                        fid = info.get("index")
+                    except Exception:
+                        pass
+
         if fid is None:
             return no_update
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -4,6 +4,7 @@ from types import ModuleType
 from pathlib import Path
 import inspect
 from types import SimpleNamespace
+import json
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -153,7 +154,8 @@ def test_floor_selection_fallback_to_triggered(monkeypatch):
     select = registered["handle_floor_selection"]
 
     for fid in [1, 2, 3]:
-        ctx = SimpleNamespace(triggered_id={"type": "floor-tile", "index": fid})
+        prop = json.dumps({"type": "floor-tile", "index": fid}) + ".n_clicks"
+        ctx = SimpleNamespace(triggered=[{"prop_id": prop}], triggered_id=None)
         monkeypatch.setattr(callbacks, "callback_context", ctx)
         data = {"selected_floor": "all"}
         result = select([], [], data)


### PR DESCRIPTION
## Summary
- restore legacy-compatible handling for floor tile clicks
- expand floor selection tests to cover callback_context.triggered fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea647aa6483279868e7d5d169fb5f