### PR TITLE
Support runtime data for floor layout

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -270,7 +270,10 @@ def register_callbacks() -> None:
                     if floor.get("editing"):
                         return no_update
 
-        return render_floor_machine_layout_with_customizable_names()
+        return render_floor_machine_layout_with_customizable_names(
+            floors_data=floors_data,
+            machines_data=machines_data,
+        )
 
     @_dash_callback(
         Output("section-1-1", "children"),

--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -328,10 +328,25 @@ def render_dashboard_wrapper() -> Any:
     )
 
 
-def render_floor_machine_layout_with_customizable_names() -> Any:
-    """Return a layout for managing floors and machines with editing controls."""
+def render_floor_machine_layout_with_customizable_names(
+    floors_data: dict | None = None,
+    machines_data: dict | None = None,
+) -> Any:
+    """Return a layout for managing floors and machines with editing controls.
 
-    floors_data, machines_data = load_layout()
+    Parameters ``floors_data`` and ``machines_data`` default to ``None`` so the
+    layout can load saved values from disk when not explicitly provided.  This
+    allows callbacks to pass the in-memory store data directly for immediate
+    updates without persisting to disk first.
+    """
+
+    if floors_data is None or machines_data is None:
+        loaded_floors, loaded_machines = load_layout()
+        if floors_data is None:
+            floors_data = loaded_floors
+        if machines_data is None:
+            machines_data = loaded_machines
+
     if not floors_data:
         floors_data = {"floors": [{"id": 1, "name": "1st Floor"}], "selected_floor": "all"}
     if not machines_data:
@@ -537,11 +552,16 @@ def render_floor_machine_layout_with_customizable_names() -> Any:
     return html.Div([layout_row, hidden_sections])
 
 
-def render_floor_machine_layout_enhanced_with_selection() -> Any:
+def render_floor_machine_layout_enhanced_with_selection(
+    floors_data: dict | None = None,
+    machines_data: dict | None = None,
+) -> Any:
     """Return floor layout including machine selection capability."""
 
     # In this simplified refactor the enhanced layout reuses the base layout.
-    return render_floor_machine_layout_with_customizable_names()
+    return render_floor_machine_layout_with_customizable_names(
+        floors_data=floors_data, machines_data=machines_data
+    )
 
 
 def build_machine_card(machine: dict, ip_options: list, *, active: bool = False, lang: str | None = None) -> Any:

--- a/tests/test_add_machine_button.py
+++ b/tests/test_add_machine_button.py
@@ -22,8 +22,10 @@ def test_button_present_for_selected_floor(monkeypatch):
     floors = {"floors": [{"id": 1, "name": "F1"}], "selected_floor": 1}
     machines = {"machines": []}
     _, _, _, layout, _ = load_modules(monkeypatch)
-    monkeypatch.setattr(layout, "load_layout", lambda: (floors, machines))
-    comp = layout.render_floor_machine_layout_with_customizable_names()
+    comp = layout.render_floor_machine_layout_with_customizable_names(
+        floors_data=floors,
+        machines_data=machines,
+    )
     assert _find_by_id(comp, "add-machine-btn")
 
 
@@ -31,6 +33,8 @@ def test_button_absent_for_all(monkeypatch):
     floors = {"floors": [{"id": 1, "name": "F1"}], "selected_floor": "all"}
     machines = {"machines": []}
     _, _, _, layout, _ = load_modules(monkeypatch)
-    monkeypatch.setattr(layout, "load_layout", lambda: (floors, machines))
-    comp = layout.render_floor_machine_layout_with_customizable_names()
+    comp = layout.render_floor_machine_layout_with_customizable_names(
+        floors_data=floors,
+        machines_data=machines,
+    )
     assert not _find_by_id(comp, "add-machine-btn")

--- a/tests/test_dashboard_utils.py
+++ b/tests/test_dashboard_utils.py
@@ -316,3 +316,30 @@ def test_floor_layout_has_hidden_sections(monkeypatch):
 
     assert "section-1-1" in ids
     assert "section-7-2" in ids
+
+
+def test_floor_layout_reflects_passed_data(monkeypatch):
+    """Layout should use provided floor and machine data immediately."""
+    _, _, _, layout, _ = load_modules(monkeypatch)
+
+    floors = {"floors": [{"id": 2, "name": "F2", "editing": True}], "selected_floor": 2}
+    machines = {"machines": []}
+
+    comp = layout.render_floor_machine_layout_with_customizable_names(
+        floors_data=floors,
+        machines_data=machines,
+    )
+
+    def find(node, target):
+        ident = getattr(node, "props", {}).get("id")
+        if ident == target:
+            return True
+        children = getattr(node, "children", []) or []
+        if len(children) == 1 and isinstance(children[0], list):
+            children = children[0]
+        for child in children:
+            if find(child, target):
+                return True
+        return False
+
+    assert find(comp, {"type": "floor-name-input", "index": 2})


### PR DESCRIPTION
## Summary
- allow passing floor/machine data directly to layout helpers
- forward store data through callbacks
- test direct parameter usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea999d1f48327917c2db8ad064db3