### PR TITLE
Fix floor selection after adding new floor

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -387,6 +387,7 @@ def register_callbacks() -> None:
         next_id = max([f.get("id", 0) for f in floors] or [0]) + 1
         floors.append({"id": next_id, "name": f"Floor {next_id}", "editing": False})
         floors_data["floors"] = floors
+        floors_data["selected_floor"] = next_id
         _save_floor_machine_data(floors_data, machines_data or {})
         return floors_data
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -160,3 +160,17 @@ def test_floor_selection_fallback_to_triggered(monkeypatch):
         data = {"selected_floor": "all"}
         result = select([], [], data)
         assert result["selected_floor"] == fid
+
+
+def test_new_floor_is_selected(monkeypatch):
+    callbacks, registered = load_callbacks(monkeypatch)
+    add_floor = registered["add_floor_cb"]
+
+    monkeypatch.setattr(callbacks, "_save_floor_machine_data", lambda f, m: True)
+
+    floors = {"floors": [{"id": 1, "name": "F1"}], "selected_floor": 1}
+    machines = {"machines": []}
+
+    result = add_floor(1, floors, machines)
+    assert result["selected_floor"] == 2
+    assert any(f.get("id") == 2 for f in result["floors"])


### PR DESCRIPTION
## Summary
- ensure newly added floor becomes the active selection
- add regression test for floor selection on add

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eaba017c083279ff06212e5af66f2