### PR TITLE
Fix machine filter for floor selection

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -526,7 +526,12 @@ def register_callbacks() -> None:
         selected = floors_data.get("selected_floor", "all")
         machines = machines_data.get("machines", [])
         if selected != "all":
-            machines = [m for m in machines if m.get("floor_id") == selected]
+            # Cast IDs to strings to avoid type mismatch when filtering
+            machines = [
+                m
+                for m in machines
+                if str(m.get("floor_id")) == str(selected)
+            ]
         from .settings import load_ip_addresses
 
         data = load_ip_addresses()

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -174,3 +174,24 @@ def test_new_floor_is_selected(monkeypatch):
     result = add_floor(1, floors, machines)
     assert result["selected_floor"] == 2
     assert any(f.get("id") == 2 for f in result["floors"])
+
+
+def test_machine_filter_by_floor(monkeypatch):
+    callbacks, registered = load_callbacks(monkeypatch)
+    add_machine = registered["add_machine_cb"]
+    render_cards = registered["render_machine_cards"]
+
+    monkeypatch.setattr(callbacks, "_save_floor_machine_data", lambda f, m: True)
+
+    floors = {
+        "floors": [{"id": 1, "name": "F1"}, {"id": 2, "name": "F2"}],
+        "selected_floor": 2,
+    }
+    machines = {"machines": []}
+
+    machines = add_machine(1, machines, floors)
+    machines["machines"].append({"id": 99, "floor_id": 1, "name": "M99"})
+
+    cards = render_cards(floors, machines, "new")
+    children = cards.children if hasattr(cards, "children") else cards[1]
+    assert len(children) == 1


### PR DESCRIPTION
## Summary
- filter machine cards using string comparison of floor ids
- add regression test for floor-specific machine filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ead503f48832782a9f5ec8ceda45d