### PR TITLE
Add ordinal floor naming

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -153,6 +153,15 @@ def _generate_csv_string(tags: dict) -> str:
     return buf.getvalue()
 
 
+def _ordinal_suffix(n: int) -> str:
+    """Return ``n`` with its ordinal suffix."""
+    if 10 <= n % 100 <= 20:
+        suffix = "th"
+    else:
+        suffix = {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
+    return f"{n}{suffix}"
+
+
 def send_threshold_email(sensitivity_num: int, is_high: bool = True) -> bool:
     """Send an email notification for a threshold violation."""
     try:
@@ -386,7 +395,7 @@ def register_callbacks() -> None:
             return no_update
         floors = list(floors_data.get("floors", []))
         next_id = max([f.get("id", 0) for f in floors] or [0]) + 1
-        floors.append({"id": next_id, "name": f"Floor {next_id}", "editing": False})
+        floors.append({"id": next_id, "name": f"{_ordinal_suffix(next_id)} Floor", "editing": False})
         new_floors = copy.deepcopy(floors_data)
         new_floors["floors"] = floors
         # Select the newly created floor so the machine list starts empty

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -174,6 +174,18 @@ def test_new_floor_is_selected(monkeypatch):
     result = add_floor(1, floors, machines)
     assert result["selected_floor"] == 2
     assert any(f.get("id") == 2 for f in result["floors"])
+    name = next((f["name"] for f in result["floors"] if f["id"] == 2), "")
+    assert name == "2nd Floor"
+
+
+def test_ordinal_suffix(monkeypatch):
+    callbacks, _ = load_callbacks(monkeypatch)
+    assert callbacks._ordinal_suffix(1) == "1st"
+    assert callbacks._ordinal_suffix(2) == "2nd"
+    assert callbacks._ordinal_suffix(3) == "3rd"
+    assert callbacks._ordinal_suffix(4) == "4th"
+    assert callbacks._ordinal_suffix(11) == "11th"
+    assert callbacks._ordinal_suffix(21) == "21st"
 
 
 def test_machine_filter_by_floor(monkeypatch):


### PR DESCRIPTION
## Summary
- add `_ordinal_suffix` helper in `dashboard.callbacks`
- name new floors using ordinal form
- verify floor names in tests
- add direct unit test for ordinal suffix helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ec6c34690832791876af248f4c81b