### PR TITLE
Use translated machine names

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -91,6 +91,7 @@ from .settings import (
     capacity_unit_label,
     load_threshold_settings,
     load_email_settings,
+    load_language_preference,
 
 )
 from .layout import (
@@ -572,7 +573,8 @@ def register_callbacks() -> None:
         if fid == "all":
             floors = floors_data.get("floors", [])
             fid = floors[0]["id"] if floors else 1
-        machines.append({"id": next_id, "floor_id": fid, "name": f"Machine {next_id}"})
+        name = f"{tr('machine_label', load_language_preference())} {next_id}"
+        machines.append({"id": next_id, "floor_id": fid, "name": name})
         new_machines = copy.deepcopy(machines_data)
         new_machines["machines"] = machines
         new_machines["next_machine_id"] = next_id + 1

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -129,6 +129,8 @@ def test_machine_cards_after_add(monkeypatch):
     machines = {"machines": []}
 
     machines = add_machine(1, machines, floors)
+    expected = f"{callbacks.tr('machine_label', callbacks.load_language_preference())} 1"
+    assert machines["machines"][0]["name"] == expected
     cards = render_cards(floors, machines, "new")
 
     assert cards is not None


### PR DESCRIPTION
## Summary
- load language preference when adding a machine
- default machine names now use translated "machine" label
- verify default machine name in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ec6ca00708327a426266125a73f95