### PR TITLE
Add summary card for machine totals

### DIFF
--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -136,7 +136,7 @@ def test_machine_cards_after_add(monkeypatch):
     assert cards is not None
     assert cards != callbacks.no_update
     children = cards.children if hasattr(cards, "children") else cards[1]
-    assert len(children) == 1
+    assert len(children) == 2
 
 
 def test_floor_selection_updates_selected(monkeypatch):
@@ -208,7 +208,7 @@ def test_machine_filter_by_floor(monkeypatch):
 
     cards = render_cards(floors, machines, "new")
     children = cards.children if hasattr(cards, "children") else cards[1]
-    assert len(children) == 1
+    assert len(children) == 2
 
 
 def test_add_floor_then_machine_filters(monkeypatch):
@@ -227,7 +227,7 @@ def test_add_floor_then_machine_filters(monkeypatch):
 
     cards = render_cards(new_floors, machines, "new")
     children = cards.children if hasattr(cards, "children") else cards[1]
-    assert len(children) == 1
+    assert len(children) == 2
     assert machines["machines"][0]["floor_id"] == new_floors["selected_floor"]
 
 
@@ -280,7 +280,7 @@ def test_add_floor_add_machine_from_all(monkeypatch):
 
     cards = render_cards(new_floors, machines, "new")
     children = cards.children if hasattr(cards, "children") else cards[1]
-    assert len(children) == 1
+    assert len(children) == 2
     assert machines["machines"][0]["floor_id"] == new_floors["selected_floor"]
 
 
@@ -308,7 +308,7 @@ def test_add_machine_does_not_change_selected_floor(monkeypatch):
 
     cards = render_cards(floors, machines, "new")
     children = cards.children if hasattr(cards, "children") else cards[1]
-    assert len(children) == 1
+    assert len(children) == 2
 
 
 def test_new_floor_layout_is_blank(monkeypatch):


### PR DESCRIPTION
## Summary
- import `load_weight_preference` and define `NUMERIC_FONT`
- compute machine totals and render summary card in `render_machine_cards`
- expect two children from render_machine_cards in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685edf9ad4d883279435f1732d299030