### PR TITLE
Add tests and callbacks for IP and theme features

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -12,6 +12,7 @@ import copy
 import smtplib
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+import time
 import generate_report
 
 # ``dash`` is optional during testing so fall back to light stubs when missing.
@@ -27,6 +28,7 @@ try:  # pragma: no cover - optional dependency
         no_update,
     )  # type: ignore
     import dash_bootstrap_components as dbc  # type: ignore
+
     HAS_DASH = True
 except Exception:  # pragma: no cover - provide minimal stubs
     from types import SimpleNamespace
@@ -70,11 +72,14 @@ from .app import app
 try:  # pragma: no cover - handle missing ``callback`` attribute
     _dash_callback = app.callback  # type: ignore[attr-defined]
 except Exception:  # pragma: no cover - when Dash is not installed
+
     def _dash_callback(*args, **kwargs):
         def wrapper(func):
             return func
 
         return wrapper
+
+
 from .state import app_state
 from .opc_client import (
     pause_update_thread,
@@ -93,7 +98,7 @@ from .settings import (
     load_email_settings,
     load_language_preference,
     load_weight_preference,
-
+    load_theme_preference,
 )
 from .layout import (
     render_new_dashboard,
@@ -211,6 +216,151 @@ def send_threshold_email(sensitivity_num: int, is_high: bool = True) -> bool:
         return False
 
 
+@_dash_callback(
+    Output("ip-addresses-store", "data"),
+    Output("new-ip-input", "value"),
+    Output("new-ip-label", "value"),
+    Output("system-settings-save-status", "children"),
+    Input("add-ip-button", "n_clicks"),
+    State("new-ip-input", "value"),
+    State("new-ip-label", "value"),
+    State("ip-addresses-store", "data"),
+    prevent_initial_call=True,
+)
+def add_ip_address(n_clicks, new_ip, new_label, current_data):
+    """Add a new IP address to the store."""
+    if not n_clicks or not new_ip or not new_ip.strip():
+        return no_update, no_update, no_update, no_update
+
+    if not new_label or not new_label.strip():
+        lang = load_language_preference()
+        new_label = (
+            f"{tr('machine_label', lang)} {len(current_data.get('addresses', [])) + 1}"
+        )
+
+    new_ip = new_ip.strip().lower()
+    localhost_formats = ["localhost", "127.0.0.1", "::1"]
+    is_valid = False
+
+    if new_ip in localhost_formats:
+        is_valid = True
+        if new_ip == "localhost":
+            new_ip = "127.0.0.1"
+    else:
+        parts = new_ip.split(".")
+        if len(parts) == 4 and all(p.isdigit() and 0 <= int(p) <= 255 for p in parts):
+            is_valid = True
+        else:
+            import re
+
+            if re.match(r"^[a-zA-Z0-9.-]+$", new_ip) and len(new_ip) > 0:
+                is_valid = True
+
+    if not is_valid:
+        return (
+            no_update,
+            "",
+            no_update,
+            "Invalid IP address, hostname, or localhost format",
+        )
+
+    addresses = current_data.get("addresses", []) if current_data else []
+    if any(item.get("ip") == new_ip for item in addresses):
+        return no_update, "", no_update, "IP address already exists"
+
+    addresses.append({"ip": new_ip, "label": new_label})
+    return {"addresses": addresses}, "", "", "IP address added successfully"
+
+
+@_dash_callback(
+    Output("saved-ip-list", "children"),
+    Input("ip-addresses-store", "data"),
+)
+def update_saved_ip_list(ip_data):
+    """Render saved IP address entries."""
+    if not ip_data or not ip_data.get("addresses"):
+        return html.Div("No IP addresses saved", className="text-muted fst-italic")
+
+    rows = []
+    for item in ip_data["addresses"]:
+        ip = item.get("ip")
+        label = item.get("label")
+        rows.append(
+            dbc.Row(
+                [
+                    dbc.Col(f"{label}: {ip}", width=9),
+                    dbc.Col(
+                        dbc.Button(
+                            "×",
+                            id={"type": "delete-ip-button", "index": ip},
+                            color="danger",
+                            size="sm",
+                            className="py-0 px-2",
+                        ),
+                        width=3,
+                        className="text-end",
+                    ),
+                ],
+                className="mb-2 border-bottom pb-2",
+            )
+        )
+    return html.Div(rows)
+
+
+@_dash_callback(
+    Output("delete-ip-trigger", "data"),
+    Input({"type": "delete-ip-button", "index": ALL}, "n_clicks"),
+    State({"type": "delete-ip-button", "index": ALL}, "id"),
+    prevent_initial_call=True,
+)
+def handle_delete_button(n_clicks_list, button_ids):
+    ctx = callback_context
+    if not ctx.triggered:
+        return no_update
+    for idx, clicks in enumerate(n_clicks_list):
+        if clicks is not None:
+            ip = button_ids[idx]["index"]
+            return {"ip": ip, "timestamp": time.time()}
+    return no_update
+
+
+@_dash_callback(
+    Output("ip-addresses-store", "data", allow_duplicate=True),
+    Output("delete-result", "children"),
+    Input("delete-ip-trigger", "data"),
+    State("ip-addresses-store", "data"),
+    prevent_initial_call=True,
+)
+def delete_ip_address(trigger_data, current_data):
+    """Remove an IP address from the store."""
+    if not trigger_data or "ip" not in trigger_data:
+        return no_update, no_update
+
+    ip_to_delete = trigger_data["ip"]
+    addresses = current_data.get("addresses", []) if current_data else []
+    message = "IP address not found"
+    for idx, item in enumerate(addresses):
+        if item.get("ip") == ip_to_delete:
+            label = item.get("label")
+            addresses.pop(idx)
+            message = f"Deleted {label} ({ip_to_delete})"
+            break
+
+    return {"addresses": addresses}, message
+
+
+@_dash_callback(
+    Output("theme-selector", "value"),
+    Input("auto-connect-trigger", "data"),
+    prevent_initial_call=False,
+)
+def load_initial_theme(trigger):
+    """Load the saved theme preference."""
+    theme = load_theme_preference()
+    logger.info("Loading initial theme: %s", theme)
+    return theme
+
+
 def register_callbacks() -> None:
     """Register core callbacks with the Dash app."""
 
@@ -272,6 +422,7 @@ def register_callbacks() -> None:
         if dashboard != "new":
             if HAS_DASH:
                 from dash.exceptions import PreventUpdate
+
                 raise PreventUpdate
             return no_update
 
@@ -279,7 +430,11 @@ def register_callbacks() -> None:
         if ctx.triggered:
             trigger_id = ctx.triggered[0]["prop_id"]
             if "machines-data" in trigger_id:
-                floors = floors_data.get("floors", []) if isinstance(floors_data, dict) else []
+                floors = (
+                    floors_data.get("floors", [])
+                    if isinstance(floors_data, dict)
+                    else []
+                )
                 for floor in floors:
                     if floor.get("editing"):
                         return no_update
@@ -331,11 +486,15 @@ def register_callbacks() -> None:
         rej_pct = rejects / total * 100 if total else 0
 
         data = production_data or {}
-        data.update({"capacity": total_capacity, "accepts": accepts, "rejects": rejects})
+        data.update(
+            {"capacity": total_capacity, "accepts": accepts, "rejects": rejects}
+        )
 
         content = html.Div(
             [
-                html.H6(tr("production_capacity_title", lang), className="text-left mb-2"),
+                html.H6(
+                    tr("production_capacity_title", lang), className="text-left mb-2"
+                ),
                 html.Div(
                     f"{total_capacity:,.0f} {capacity_unit_label(pref)}",
                     className="fw-bold",
@@ -385,7 +544,7 @@ def register_callbacks() -> None:
                         return no_update
             else:
                 return no_update
-        
+
         if fid is None:
             return no_update
 
@@ -404,7 +563,13 @@ def register_callbacks() -> None:
             return no_update
         floors = list(floors_data.get("floors", []))
         next_id = max([f.get("id", 0) for f in floors] or [0]) + 1
-        floors.append({"id": next_id, "name": f"{_ordinal_suffix(next_id)} Floor", "editing": False})
+        floors.append(
+            {
+                "id": next_id,
+                "name": f"{_ordinal_suffix(next_id)} Floor",
+                "editing": False,
+            }
+        )
         new_floors = copy.deepcopy(floors_data)
         new_floors["floors"] = floors
         # Select the newly created floor so the machine list starts empty
@@ -520,7 +685,11 @@ def register_callbacks() -> None:
                 if c and i < len(floor_ids):
                     fid = floor_ids[i]["index"]
                     name = next(
-                        (f.get("name", f"Floor {fid}") for f in floors_data.get("floors", []) if f.get("id") == fid),
+                        (
+                            f.get("name", f"Floor {fid}")
+                            for f in floors_data.get("floors", [])
+                            if f.get("id") == fid
+                        ),
                         f"Floor {fid}",
                     )
                     return True, name, {"type": "floor", "id": fid}
@@ -529,7 +698,11 @@ def register_callbacks() -> None:
                 if c and i < len(machine_ids):
                     mid = machine_ids[i]["index"]
                     name = next(
-                        (m.get("name", f"Machine {mid}") for m in machines_data.get("machines", []) if m.get("id") == mid),
+                        (
+                            m.get("name", f"Machine {mid}")
+                            for m in machines_data.get("machines", [])
+                            if m.get("id") == mid
+                        ),
                         f"Machine {mid}",
                     )
                     return True, name, {"type": "machine", "id": mid}
@@ -548,11 +721,7 @@ def register_callbacks() -> None:
         machines = machines_data.get("machines", [])
         if selected != "all":
             # Cast IDs to strings to avoid type mismatch when filtering by floor
-            machines = [
-                m
-                for m in machines
-                if str(m.get("floor_id")) == str(selected)
-            ]
+            machines = [m for m in machines if str(m.get("floor_id")) == str(selected)]
         from .settings import load_ip_addresses
 
         data = load_ip_addresses()
@@ -562,11 +731,12 @@ def register_callbacks() -> None:
             if isinstance(item, dict) and "ip" in item and "label" in item
         ]
         if not ip_options:
-            ip_options = [{"label": "Default (192.168.0.125)", "value": "192.168.0.125"}]
+            ip_options = [
+                {"label": "Default (192.168.0.125)", "value": "192.168.0.125"}
+            ]
 
         cols = [
-            dbc.Col(build_machine_card(m, ip_options), xs=6, md=4)
-            for m in machines
+            dbc.Col(build_machine_card(m, ip_options), xs=6, md=4) for m in machines
         ]
         if not cols:
             return html.Div("No machines configured")
@@ -671,12 +841,20 @@ def register_callbacks() -> None:
         item_type = pending.get("type")
         item_id = pending.get("id")
         if item_type == "floor":
-            floors_data["floors"] = [f for f in floors_data.get("floors", []) if f.get("id") != item_id]
-            machines_data["machines"] = [m for m in machines_data.get("machines", []) if m.get("floor_id") != item_id]
+            floors_data["floors"] = [
+                f for f in floors_data.get("floors", []) if f.get("id") != item_id
+            ]
+            machines_data["machines"] = [
+                m
+                for m in machines_data.get("machines", [])
+                if m.get("floor_id") != item_id
+            ]
             if floors_data.get("selected_floor") == item_id:
                 floors_data["selected_floor"] = "all"
         elif item_type == "machine":
-            machines_data["machines"] = [m for m in machines_data.get("machines", []) if m.get("id") != item_id]
+            machines_data["machines"] = [
+                m for m in machines_data.get("machines", []) if m.get("id") != item_id
+            ]
         else:
             return no_update, no_update, False
         _save_floor_machine_data(floors_data, machines_data)
@@ -795,6 +973,7 @@ def register_callbacks() -> None:
         try:
             from dash.exceptions import PreventUpdate
         except Exception:  # pragma: no cover - dash missing
+
             class PreventUpdate(Exception):
                 pass
 
@@ -919,16 +1098,28 @@ def register_callbacks() -> None:
             import plotly.graph_objects as go
 
             fig1 = go.Figure(
-                data=[go.Pie(labels=[tr("accepts", lang), tr("rejects", lang)], values=[accepts, rejects], hole=0.4)]
+                data=[
+                    go.Pie(
+                        labels=[tr("accepts", lang), tr("rejects", lang)],
+                        values=[accepts, rejects],
+                        hole=0.4,
+                    )
+                ]
             )
             fig1.update_layout(margin=dict(l=10, r=10, t=20, b=20), showlegend=False)
 
             total_counter = sum(previous_counter_values)
             labels = [str(i) for i, v in enumerate(previous_counter_values, 1) if v > 0]
-            values = [v / total_counter * 100 for v in previous_counter_values if v > 0] if total_counter else []
-            fig2 = go.Figure(
-                data=[go.Pie(labels=labels, values=values, hole=0.4)]
-            ) if values else go.Figure()
+            values = (
+                [v / total_counter * 100 for v in previous_counter_values if v > 0]
+                if total_counter
+                else []
+            )
+            fig2 = (
+                go.Figure(data=[go.Pie(labels=labels, values=values, hole=0.4)])
+                if values
+                else go.Figure()
+            )
             fig2.update_layout(margin=dict(l=10, r=10, t=20, b=20), showlegend=False)
 
             graph1 = dcc.Graph(
@@ -949,10 +1140,13 @@ def register_callbacks() -> None:
             graph1 = html.Div(f"{acc_pct:.1f}% / {rej_pct:.1f}%")
             graph2 = html.Div("N/A")
 
-        return html.Div([
-            html.Div(graph1, className="col-6"),
-            html.Div(graph2, className="col-6"),
-        ], className="row")
+        return html.Div(
+            [
+                html.Div(graph1, className="col-6"),
+                html.Div(graph2, className="col-6"),
+            ],
+            className="row",
+        )
 
     @_dash_callback(
         Output("section-3-2", "children"),
@@ -974,13 +1168,17 @@ def register_callbacks() -> None:
                 val = app_state.tags[model_tag]["data"].latest_value
                 model = val if val is not None else ""
 
-        status_text = tr("good_status", lang) if app_state.connected else tr("fault_status", lang)
-        return html.Div([
-            html.H6(tr("machine_info_title", lang)),
-            html.Div(f"{tr('serial_number_label', lang)} {serial}"),
-            html.Div(f"{tr('model_label', lang)} {model}"),
-            html.Div(f"Status: {status_text}"),
-        ])
+        status_text = (
+            tr("good_status", lang) if app_state.connected else tr("fault_status", lang)
+        )
+        return html.Div(
+            [
+                html.H6(tr("machine_info_title", lang)),
+                html.Div(f"{tr('serial_number_label', lang)} {serial}"),
+                html.Div(f"{tr('model_label', lang)} {model}"),
+                html.Div(f"Status: {status_text}"),
+            ]
+        )
 
     @_dash_callback(
         Output("section-2", "children"),
@@ -1036,11 +1234,20 @@ def register_callbacks() -> None:
                 if bool(app_state.tags[tag]["data"].latest_value):
                     running = True
                     break
-        feeder_text = tr("running_state", lang) if running else tr("stopped_state", lang)
-        feeder_style = {"backgroundColor": "#28a745" if running else "#6c757d", "color": "white"}
+        feeder_text = (
+            tr("running_state", lang) if running else tr("stopped_state", lang)
+        )
+        feeder_style = {
+            "backgroundColor": "#28a745" if running else "#6c757d",
+            "color": "white",
+        }
 
         boxes = [
-            html.Div(preset, className="mb-1 p-1", style={"backgroundColor": "#28a745", "color": "white"}),
+            html.Div(
+                preset,
+                className="mb-1 p-1",
+                style={"backgroundColor": "#28a745", "color": "white"},
+            ),
             html.Div(status_text, className="mb-1 p-1", style=status_style),
             html.Div(feeder_text, className="mb-2 p-1", style=feeder_style),
         ]
@@ -1056,15 +1263,20 @@ def register_callbacks() -> None:
                 html.Div(
                     f"F{i}: {rate}",
                     className="me-1 p-1",
-                    style={"backgroundColor": "#28a745" if running else "#6c757d", "color": "white"},
+                    style={
+                        "backgroundColor": "#28a745" if running else "#6c757d",
+                        "color": "white",
+                    },
                 )
             )
 
-        return html.Div([
-            html.H6(tr("machine_status_title", lang)),
-            *boxes,
-            html.Div(rate_boxes, className="d-flex"),
-        ])
+        return html.Div(
+            [
+                html.H6(tr("machine_status_title", lang)),
+                *boxes,
+                html.Div(rate_boxes, className="d-flex"),
+            ]
+        )
 
     @_dash_callback(
         Output("section-3-1", "children"),
@@ -1080,21 +1292,55 @@ def register_callbacks() -> None:
         if isinstance(img_data, dict):
             image_src = img_data.get("image")
         if image_src:
-            image = html.Img(src=image_src, style={"maxWidth": "100%", "maxHeight": "130px", "objectFit": "contain", "display": "block", "margin": "0 auto"})
+            image = html.Img(
+                src=image_src,
+                style={
+                    "maxWidth": "100%",
+                    "maxHeight": "130px",
+                    "objectFit": "contain",
+                    "display": "block",
+                    "margin": "0 auto",
+                },
+            )
         else:
-            image = html.Div("No custom image loaded", className="text-muted text-center", style={"height": "130px", "display": "flex", "alignItems": "center", "justifyContent": "center"})
+            image = html.Div(
+                "No custom image loaded",
+                className="text-muted text-center",
+                style={
+                    "height": "130px",
+                    "display": "flex",
+                    "alignItems": "center",
+                    "justifyContent": "center",
+                },
+            )
 
-        return html.Div([
-            dbc.Row([
-                dbc.Col(html.H6(tr("corporate_logo_title", lang)), width=8),
-                dbc.Col(dbc.Button(tr("load_image_button", lang), id="load-additional-image", size="sm", color="primary"), width=4),
-            ], className="mb-2"),
-            image,
-        ])
+        return html.Div(
+            [
+                dbc.Row(
+                    [
+                        dbc.Col(html.H6(tr("corporate_logo_title", lang)), width=8),
+                        dbc.Col(
+                            dbc.Button(
+                                tr("load_image_button", lang),
+                                id="load-additional-image",
+                                size="sm",
+                                color="primary",
+                            ),
+                            width=4,
+                        ),
+                    ],
+                    className="mb-2",
+                ),
+                image,
+            ]
+        )
 
     @_dash_callback(
         Output("upload-modal", "is_open"),
-        [Input("load-additional-image", "n_clicks"), Input("close-upload-modal", "n_clicks")],
+        [
+            Input("load-additional-image", "n_clicks"),
+            Input("close-upload-modal", "n_clicks"),
+        ],
         [State("upload-modal", "is_open")],
         prevent_initial_call=True,
     )
@@ -1131,7 +1377,9 @@ def register_callbacks() -> None:
             return new_data, html.Div(f"Uploaded: {filename}", className="text-success")
         except Exception as exc:  # pragma: no cover - unexpected errors
             logger.error("Error uploading image: %s", exc)
-            return no_update, html.Div(f"Error uploading image: {exc}", className="text-danger")
+            return no_update, html.Div(
+                f"Error uploading image: {exc}", className="text-danger"
+            )
 
     @_dash_callback(
         Output("section-4", "children"),
@@ -1152,10 +1400,12 @@ def register_callbacks() -> None:
                     name = val
             items.append(html.Li(f"{i}. {name}", className="mb-1"))
 
-        return html.Div([
-            html.H6(tr("sensitivities_title", lang)),
-            html.Ul(items, className="mb-0"),
-        ])
+        return html.Div(
+            [
+                html.H6(tr("sensitivities_title", lang)),
+                html.Ul(items, className="mb-0"),
+            ]
+        )
 
     @_dash_callback(
         Output("section-5-1", "children"),
@@ -1176,7 +1426,10 @@ def register_callbacks() -> None:
             production_history[:] = production_history[-60:]
         try:
             import plotly.graph_objects as go
-            fig = go.Figure(go.Scatter(x=list(range(len(production_history))), y=production_history))
+
+            fig = go.Figure(
+                go.Scatter(x=list(range(len(production_history))), y=production_history)
+            )
             fig.update_layout(margin=dict(l=20, r=20, t=20, b=20), showlegend=False)
             graph = dcc.Graph(
                 figure=fig,
@@ -1185,13 +1438,28 @@ def register_callbacks() -> None:
             )
         except Exception:  # pragma: no cover - plotly missing
             graph = html.Div(str(val))
-        return html.Div([
-            dbc.Row([
-                dbc.Col(html.H6(tr("production_rate_objects_title", lang)), width=9),
-                dbc.Col(dbc.Button("Units", id={"type": "open-production-rate-units", "index": 0}, size="sm", color="primary"), width=3),
-            ], className="mb-2"),
-            graph,
-        ])
+        return html.Div(
+            [
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            html.H6(tr("production_rate_objects_title", lang)), width=9
+                        ),
+                        dbc.Col(
+                            dbc.Button(
+                                "Units",
+                                id={"type": "open-production-rate-units", "index": 0},
+                                size="sm",
+                                color="primary",
+                            ),
+                            width=3,
+                        ),
+                    ],
+                    className="mb-2",
+                ),
+                graph,
+            ]
+        )
 
     @_dash_callback(
         Output("section-6-1", "children"),
@@ -1210,9 +1478,16 @@ def register_callbacks() -> None:
                 counter_history[i] = hist[-60:]
         try:
             import plotly.graph_objects as go
+
             fig = go.Figure()
             for i in range(1, 13):
-                fig.add_trace(go.Scatter(x=list(range(len(counter_history[i]))), y=counter_history[i], name=str(i)))
+                fig.add_trace(
+                    go.Scatter(
+                        x=list(range(len(counter_history[i]))),
+                        y=counter_history[i],
+                        name=str(i),
+                    )
+                )
             fig.update_layout(margin=dict(l=20, r=20, t=20, b=20), showlegend=False)
             graph = dcc.Graph(
                 figure=fig,
@@ -1221,13 +1496,28 @@ def register_callbacks() -> None:
             )
         except Exception:  # pragma: no cover - plotly missing
             graph = html.Div("N/A")
-        return html.Div([
-            dbc.Row([
-                dbc.Col(html.H6(tr("counter_values_trend_title", lang)), width=9),
-                dbc.Col(dbc.Button("Display", id={"type": "open-display", "index": 0}, size="sm", color="primary"), width=3),
-            ], className="mb-2"),
-            graph,
-        ])
+        return html.Div(
+            [
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            html.H6(tr("counter_values_trend_title", lang)), width=9
+                        ),
+                        dbc.Col(
+                            dbc.Button(
+                                "Display",
+                                id={"type": "open-display", "index": 0},
+                                size="sm",
+                                color="primary",
+                            ),
+                            width=3,
+                        ),
+                    ],
+                    className="mb-2",
+                ),
+                graph,
+            ]
+        )
 
     @_dash_callback(
         Output("section-7-1", "children"),
@@ -1245,7 +1535,14 @@ def register_callbacks() -> None:
             value = raw / 100 if raw is not None else 0
         try:
             import plotly.graph_objects as go
-            fig = go.Figure(go.Indicator(mode="gauge+number", value=value, gauge={"axis": {"range": [0, 100]}}))
+
+            fig = go.Figure(
+                go.Indicator(
+                    mode="gauge+number",
+                    value=value,
+                    gauge={"axis": {"range": [0, 100]}},
+                )
+            )
             fig.update_layout(margin=dict(l=20, r=20, t=30, b=20))
             graph = dcc.Graph(
                 figure=fig,
@@ -1254,10 +1551,12 @@ def register_callbacks() -> None:
             )
         except Exception:  # pragma: no cover - plotly missing
             graph = html.Div(str(value))
-        return html.Div([
-            html.H6(tr("air_pressure_title", lang)),
-            graph,
-        ])
+        return html.Div(
+            [
+                html.H6(tr("air_pressure_title", lang)),
+                graph,
+            ]
+        )
 
     @_dash_callback(
         Output("section-5-2", "children"),
@@ -1342,20 +1641,32 @@ def register_callbacks() -> None:
             mid = len(alarms) // 2 + len(alarms) % 2
             left = [html.Li(a, className="text-danger mb-1") for a in alarms[:mid]]
             right = [html.Li(a, className="text-danger mb-1") for a in alarms[mid:]]
-            alarm_display = html.Div([
-                html.Div(tr("active_alarms_title", lang), className="fw-bold text-danger mb-2"),
-                html.Div([
-                    html.Ul(left, className="ps-3 mb-0 col-6"),
-                    html.Ul(right, className="ps-3 mb-0 col-6"),
-                ], className="row"),
-            ])
+            alarm_display = html.Div(
+                [
+                    html.Div(
+                        tr("active_alarms_title", lang),
+                        className="fw-bold text-danger mb-2",
+                    ),
+                    html.Div(
+                        [
+                            html.Ul(left, className="ps-3 mb-0 col-6"),
+                            html.Ul(right, className="ps-3 mb-0 col-6"),
+                        ],
+                        className="row",
+                    ),
+                ]
+            )
         else:
-            alarm_display = html.Div(tr("no_changes_yet", lang), className="text-success")
+            alarm_display = html.Div(
+                tr("no_changes_yet", lang), className="text-success"
+            )
 
-        return html.Div([
-            html.H6(tr("sensitivity_threshold_alarms_title", lang)),
-            alarm_display,
-        ])
+        return html.Div(
+            [
+                html.H6(tr("sensitivity_threshold_alarms_title", lang)),
+                alarm_display,
+            ]
+        )
 
     @_dash_callback(
         Output("section-7-2", "children"),
@@ -1375,10 +1686,12 @@ def register_callbacks() -> None:
         if not rows:
             rows.append(html.Div(tr("no_changes_yet", lang), className="text-muted"))
 
-        return html.Div([
-            html.H6(tr("machine_control_log_title", lang)),
-            *rows,
-        ])
+        return html.Div(
+            [
+                html.H6(tr("machine_control_log_title", lang)),
+                *rows,
+            ]
+        )
 
 
 register_callbacks()
@@ -1386,4 +1699,9 @@ register_callbacks()
 __all__ = [
     "register_callbacks",
     "generate_report_callback",
+    "add_ip_address",
+    "update_saved_ip_list",
+    "handle_delete_button",
+    "delete_ip_address",
+    "load_initial_theme",
 ]


### PR DESCRIPTION
## Summary
- implement IP address management callbacks and theme loader
- export new callbacks and update imports
- extend callback tests for theme and IP address operations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f33fe012c832780504316ff5ddf87