### PR TITLE
Remove duplicate IP callbacks

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -217,137 +217,137 @@ def send_threshold_email(sensitivity_num: int, is_high: bool = True) -> bool:
         return False
 
 
-@_dash_callback(
-    Output("ip-addresses-store", "data"),
-    Output("new-ip-input", "value"),
-    Output("new-ip-label", "value"),
-    Output("system-settings-save-status", "children"),
-    Input("add-ip-button", "n_clicks"),
-    State("new-ip-input", "value"),
-    State("new-ip-label", "value"),
-    State("ip-addresses-store", "data"),
-    prevent_initial_call=True,
-)
-def add_ip_address(n_clicks, new_ip, new_label, current_data):
-    """Add a new IP address to the store."""
-    if not n_clicks or not new_ip or not new_ip.strip():
-        return no_update, no_update, no_update, no_update
-
-    if not new_label or not new_label.strip():
-        lang = load_language_preference()
-        new_label = (
-            f"{tr('machine_label', lang)} {len(current_data.get('addresses', [])) + 1}"
-        )
-
-    new_ip = new_ip.strip().lower()
-    localhost_formats = ["localhost", "127.0.0.1", "::1"]
-    is_valid = False
-
-    if new_ip in localhost_formats:
-        is_valid = True
-        if new_ip == "localhost":
-            new_ip = "127.0.0.1"
-    else:
-        parts = new_ip.split(".")
-        if len(parts) == 4 and all(p.isdigit() and 0 <= int(p) <= 255 for p in parts):
-            is_valid = True
-        else:
-            import re
-
-            if re.match(r"^[a-zA-Z0-9.-]+$", new_ip) and len(new_ip) > 0:
-                is_valid = True
-
-    if not is_valid:
-        return (
-            no_update,
-            "",
-            no_update,
-            "Invalid IP address, hostname, or localhost format",
-        )
-
-    addresses = current_data.get("addresses", []) if current_data else []
-    if any(item.get("ip") == new_ip for item in addresses):
-        return no_update, "", no_update, "IP address already exists"
-
-    addresses.append({"ip": new_ip, "label": new_label})
-    return {"addresses": addresses}, "", "", "IP address added successfully"
-
-
-@_dash_callback(
-    Output("saved-ip-list", "children"),
-    Input("ip-addresses-store", "data"),
-)
-def update_saved_ip_list(ip_data):
-    """Render saved IP address entries."""
-    if not ip_data or not ip_data.get("addresses"):
-        return html.Div("No IP addresses saved", className="text-muted fst-italic")
-
-    rows = []
-    for item in ip_data["addresses"]:
-        ip = item.get("ip")
-        label = item.get("label")
-        rows.append(
-            dbc.Row(
-                [
-                    dbc.Col(f"{label}: {ip}", width=9),
-                    dbc.Col(
-                        dbc.Button(
-                            "×",
-                            id={"type": "delete-ip-button", "index": ip},
-                            color="danger",
-                            size="sm",
-                            className="py-0 px-2",
-                        ),
-                        width=3,
-                        className="text-end",
-                    ),
-                ],
-                className="mb-2 border-bottom pb-2",
-            )
-        )
-    return html.Div(rows)
-
-
-@_dash_callback(
-    Output("delete-ip-trigger", "data"),
-    Input({"type": "delete-ip-button", "index": ALL}, "n_clicks"),
-    State({"type": "delete-ip-button", "index": ALL}, "id"),
-    prevent_initial_call=True,
-)
-def handle_delete_button(n_clicks_list, button_ids):
-    ctx = callback_context
-    if not ctx.triggered:
-        return no_update
-    for idx, clicks in enumerate(n_clicks_list):
-        if clicks is not None:
-            ip = button_ids[idx]["index"]
-            return {"ip": ip, "timestamp": time.time()}
-    return no_update
-
-
-@_dash_callback(
-    Output("ip-addresses-store", "data", allow_duplicate=True),
-    Output("delete-result", "children"),
-    Input("delete-ip-trigger", "data"),
-    State("ip-addresses-store", "data"),
-    prevent_initial_call=True,
-)
-def delete_ip_address(trigger_data, current_data):
-    """Remove an IP address from the store."""
-    if not trigger_data or "ip" not in trigger_data:
-        return no_update, no_update
-
-    ip_to_delete = trigger_data["ip"]
-    addresses = current_data.get("addresses", []) if current_data else []
-    message = "IP address not found"
-    for idx, item in enumerate(addresses):
-        if item.get("ip") == ip_to_delete:
-            label = item.get("label")
-            addresses.pop(idx)
-            message = f"Deleted {label} ({ip_to_delete})"
-            break
-
-    return {"addresses": addresses}, message
+#@_dash_callback(
+#    Output("ip-addresses-store", "data"),
+#    Output("new-ip-input", "value"),
+#    Output("new-ip-label", "value"),
+#    Output("system-settings-save-status", "children"),
+#    Input("add-ip-button", "n_clicks"),
+#    State("new-ip-input", "value"),
+#    State("new-ip-label", "value"),
+#    State("ip-addresses-store", "data"),
+#    prevent_initial_call=True,
+#)
+#def add_ip_address(n_clicks, new_ip, new_label, current_data):
+#    """Add a new IP address to the store."""
+#    if not n_clicks or not new_ip or not new_ip.strip():
+#        return no_update, no_update, no_update, no_update
+#
+#    if not new_label or not new_label.strip():
+#        lang = load_language_preference()
+#        new_label = (
+#            f"{tr('machine_label', lang)} {len(current_data.get('addresses', [])) + 1}"
+#        )
+#
+#    new_ip = new_ip.strip().lower()
+#    localhost_formats = ["localhost", "127.0.0.1", "::1"]
+#    is_valid = False
+#
+#    if new_ip in localhost_formats:
+#        is_valid = True
+#        if new_ip == "localhost":
+#            new_ip = "127.0.0.1"
+#    else:
+#        parts = new_ip.split(".")
+#        if len(parts) == 4 and all(p.isdigit() and 0 <= int(p) <= 255 for p in parts):
+#            is_valid = True
+#        else:
+#            import re
+#
+#            if re.match(r"^[a-zA-Z0-9.-]+$", new_ip) and len(new_ip) > 0:
+#                is_valid = True
+#
+#    if not is_valid:
+#        return (
+#            no_update,
+#            "",
+#            no_update,
+#            "Invalid IP address, hostname, or localhost format",
+#        )
+#
+#    addresses = current_data.get("addresses", []) if current_data else []
+#    if any(item.get("ip") == new_ip for item in addresses):
+#        return no_update, "", no_update, "IP address already exists"
+#
+#    addresses.append({"ip": new_ip, "label": new_label})
+#    return {"addresses": addresses}, "", "", "IP address added successfully"
+#
+#
+#@_dash_callback(
+#    Output("saved-ip-list", "children"),
+#    Input("ip-addresses-store", "data"),
+#)
+#def update_saved_ip_list(ip_data):
+#    """Render saved IP address entries."""
+#    if not ip_data or not ip_data.get("addresses"):
+#        return html.Div("No IP addresses saved", className="text-muted fst-italic")
+#
+#    rows = []
+#    for item in ip_data["addresses"]:
+#        ip = item.get("ip")
+#        label = item.get("label")
+#        rows.append(
+#            dbc.Row(
+#                [
+#                    dbc.Col(f"{label}: {ip}", width=9),
+#                    dbc.Col(
+#                        dbc.Button(
+#                            "×",
+#                            id={"type": "delete-ip-button", "index": ip},
+#                            color="danger",
+#                            size="sm",
+#                            className="py-0 px-2",
+#                        ),
+#                        width=3,
+#                        className="text-end",
+#                    ),
+#                ],
+#                className="mb-2 border-bottom pb-2",
+#            )
+#        )
+#    return html.Div(rows)
+#
+#
+#@_dash_callback(
+#    Output("delete-ip-trigger", "data"),
+#    Input({"type": "delete-ip-button", "index": ALL}, "n_clicks"),
+#    State({"type": "delete-ip-button", "index": ALL}, "id"),
+#    prevent_initial_call=True,
+#)
+#def handle_delete_button(n_clicks_list, button_ids):
+#    ctx = callback_context
+#    if not ctx.triggered:
+#        return no_update
+#    for idx, clicks in enumerate(n_clicks_list):
+#        if clicks is not None:
+#            ip = button_ids[idx]["index"]
+#            return {"ip": ip, "timestamp": time.time()}
+#    return no_update
+#
+#
+#@_dash_callback(
+#    Output("ip-addresses-store", "data", allow_duplicate=True),
+#    Output("delete-result", "children"),
+#    Input("delete-ip-trigger", "data"),
+#    State("ip-addresses-store", "data"),
+#    prevent_initial_call=True,
+#)
+#def delete_ip_address(trigger_data, current_data):
+#    """Remove an IP address from the store."""
+#    if not trigger_data or "ip" not in trigger_data:
+#        return no_update, no_update
+#
+#    ip_to_delete = trigger_data["ip"]
+#    addresses = current_data.get("addresses", []) if current_data else []
+#    message = "IP address not found"
+#    for idx, item in enumerate(addresses):
+#        if item.get("ip") == ip_to_delete:
+#            label = item.get("label")
+#            addresses.pop(idx)
+#            message = f"Deleted {label} ({ip_to_delete})"
+#            break
+#
+#    return {"addresses": addresses}, message
 
 
 @_dash_callback(
@@ -976,6 +976,15 @@ def register_callbacks() -> None:
         return html.Div(rows)
 
     @_dash_callback(
+        Output("saved-ip-list", "children"),
+        Input("ip-addresses-store", "data"),
+    )
+    def update_saved_ip_list(ip_data):
+        return _render_saved_ip_list(ip_data)
+
+    globals()["update_saved_ip_list"] = update_saved_ip_list
+
+    @_dash_callback(
         Output("theme-selector", "value"),
         Input("theme-selector", "value"),
         prevent_initial_call=False,
@@ -995,7 +1004,6 @@ def register_callbacks() -> None:
 
     @_dash_callback(
         Output("ip-addresses-store", "data", allow_duplicate=True),
-        Output("saved-ip-list", "children"),
         Output("new-ip-input", "value"),
         Output("new-ip-label", "value"),
         Output("system-settings-save-status", "children", allow_duplicate=True),
@@ -1007,7 +1015,7 @@ def register_callbacks() -> None:
     )
     def add_ip_address(n_clicks, new_ip, new_label, current_data):
         if not n_clicks or not (new_ip and new_ip.strip()):
-            return no_update, no_update, no_update, no_update, no_update
+            return no_update, no_update, no_update, no_update
 
         if not new_label or not new_label.strip():
             lang = load_language_preference()
@@ -1030,16 +1038,18 @@ def register_callbacks() -> None:
                     valid = True
 
         if not valid:
-            return no_update, no_update, "", no_update, "Invalid IP address, hostname, or localhost format"
+            return no_update, no_update, "", "Invalid IP address, hostname, or localhost format"
 
         addresses = list(current_data.get("addresses", []))
         if any(item.get("ip") == ip for item in addresses):
-            return no_update, no_update, "", no_update, "IP address already exists"
+            return no_update, no_update, "", "IP address already exists"
 
         addresses.append({"ip": ip, "label": new_label})
         new_data = {"addresses": addresses}
         save_ip_addresses(new_data)
-        return new_data, _render_saved_ip_list(new_data), "", "", "IP address added successfully"
+        return new_data, "", "", "IP address added successfully"
+
+    globals()["add_ip_address"] = add_ip_address
 
     @_dash_callback(
         Output("delete-ip-trigger", "data"),
@@ -1061,9 +1071,10 @@ def register_callbacks() -> None:
         ip_to_delete = button_ids[idx]["index"]
         return {"ip": ip_to_delete, "timestamp": datetime.now().timestamp()}
 
+    globals()["handle_delete_button"] = handle_delete_button
+
     @_dash_callback(
         Output("ip-addresses-store", "data", allow_duplicate=True),
-        Output("saved-ip-list", "children"),
         Output("delete-result", "children"),
         Input("delete-ip-trigger", "data"),
         State("ip-addresses-store", "data"),
@@ -1071,7 +1082,7 @@ def register_callbacks() -> None:
     )
     def delete_ip_address(trigger_data, current_data):
         if not trigger_data or "ip" not in trigger_data:
-            return no_update, no_update, no_update
+            return no_update, no_update
         ip_to_delete = trigger_data["ip"]
         addresses = list(current_data.get("addresses", []))
         found = False
@@ -1085,7 +1096,9 @@ def register_callbacks() -> None:
         message = f"Deleted {label} ({ip_to_delete})" if found else "IP address not found"
         new_data = {"addresses": addresses}
         save_ip_addresses(new_data)
-        return new_data, _render_saved_ip_list(new_data), message
+        return new_data, message
+
+    globals()["delete_ip_address"] = delete_ip_address
 
     @_dash_callback(
         Output("export-download", "data"),


### PR DESCRIPTION
## Summary
- comment out old IP address management callbacks in `dashboard/callbacks.py`
- expose the versions inside `register_callbacks()` and add a missing `update_saved_ip_list`
- adjust return values so public APIs remain the same

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f374fccac8327a620aaee35dc9567