### PR TITLE
Fix Dash duplicate callback error

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -353,7 +353,7 @@ def send_threshold_email(sensitivity_num: int, is_high: bool = True) -> bool:
 @_dash_callback(
     Output("theme-selector", "value", allow_duplicate=True),
     Input("auto-connect-trigger", "data"),
-    prevent_initial_call=False,
+    prevent_initial_call="initial_duplicate",
 )
 def load_initial_theme(trigger):
     """Load the saved theme preference."""
@@ -987,7 +987,7 @@ def register_callbacks() -> None:
     @_dash_callback(
         Output("theme-selector", "value", allow_duplicate=True),
         Input("theme-selector", "value"),
-        prevent_initial_call=False,
+        prevent_initial_call="initial_duplicate",
     )
     def load_initial_theme(_value):
         return load_theme_preference()


### PR DESCRIPTION
## Summary
- configure theme callbacks for duplicate outputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f3c374dd88327a0ba571c6ae03b2d