### PR TITLE
Remove unused header settings button

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -1158,20 +1158,17 @@ def register_callbacks() -> None:
         Output("settings-modal", "is_open"),
         [
             Input("settings-button", "n_clicks"),
-            Input("header-settings-button", "n_clicks"),
             Input("close-settings", "n_clicks"),
         ],
         [State("settings-modal", "is_open")],
         prevent_initial_call=True,
     )
-    def toggle_settings_modal(side_clicks, header_clicks, close_clicks, is_open):
+    def toggle_settings_modal(side_clicks, close_clicks, is_open):
         ctx = callback_context
         if not ctx.triggered:
             return no_update
         trigger = ctx.triggered[0]["prop_id"].split(".")[0]
-        if trigger in ("settings-button", "header-settings-button") and (
-            side_clicks or header_clicks
-        ):
+        if trigger == "settings-button" and side_clicks:
             return not is_open
         if trigger == "close-settings" and close_clicks:
             return False

--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -100,8 +100,6 @@ def render_dashboard_shell() -> Any:
                 [
                     dbc.Button(tr("switch_dashboards"), id="new-dashboard-btn", color="light", size="sm", className="me-2"),
                     dbc.Button(tr("generate_report"), id="generate-report-btn", color="light", size="sm", className="me-2"),
-                    # settings button in the header opens the configuration modal
-                    dbc.Button(html.I(className="fas fa-cog"), id="header-settings-button", color="secondary", size="sm"),
                     dcc.Download(id="report-download"),
                 ],
                 className="ms-auto d-flex align-items-center",

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -412,3 +412,22 @@ def test_add_and_delete_ip_address(monkeypatch):
         assert children[0] == "No IP addresses saved"
     else:
         assert children == "No IP addresses saved"
+
+
+def test_settings_modal_toggle_single_button(monkeypatch):
+    callbacks, registered = load_callbacks(monkeypatch)
+    toggle = registered["toggle_settings_modal"]
+
+    ctx = SimpleNamespace(
+        triggered=[{"prop_id": "settings-button.n_clicks", "value": 1}],
+        triggered_id=None,
+    )
+    monkeypatch.setattr(callbacks, "callback_context", ctx)
+    assert toggle(1, None, False) is True
+
+    ctx = SimpleNamespace(
+        triggered=[{"prop_id": "close-settings.n_clicks", "value": 1}],
+        triggered_id=None,
+    )
+    monkeypatch.setattr(callbacks, "callback_context", ctx)
+    assert toggle(None, 1, True) is False


### PR DESCRIPTION
## Summary
- clean up header layout by removing unused button
- drop unused callback input for the button
- add unit test ensuring settings modal toggles with a single button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f3f77e5648327ab9fe2802f5926b4