### PR TITLE
Decouple image save helper from reconnection

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -106,6 +106,7 @@ from .layout import (
     render_floor_machine_layout_with_customizable_names,
     build_machine_card,
 )
+from .images import save_uploaded_image
 
 
 from i18n import tr

--- a/dashboard/reconnection.py
+++ b/dashboard/reconnection.py
@@ -128,23 +128,8 @@ def load_saved_image():
         return {}
 
 
-def save_uploaded_image(image_data: str) -> bool:
-    """Persist ``image_data`` to :mod:`data/custom_image.txt`."""
-
-    path = Path(__file__).resolve().parents[1] / "data" / "custom_image.txt"
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w") as fh:
-            fh.write(image_data)
-        logger.info("Custom image saved successfully")
-        return True
-    except Exception as exc:  # pragma: no cover - rely on filesystem
-        logger.error("Error saving custom image: %s", exc)
-        return False
-
 __all__ = [
     "start_auto_reconnection",
     "delayed_startup_connect",
     "load_saved_image",
-    "save_uploaded_image",
 ]


### PR DESCRIPTION
## Summary
- remove `save_uploaded_image` from `dashboard.reconnection`
- use the helper from `dashboard.images` inside callbacks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f47b60f748327907b3d07fa382925