### PR TITLE
Unify email helper

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -9,11 +9,8 @@ from pathlib import Path
 import base64
 import tempfile
 import copy
-import smtplib
-from email.mime.text import MIMEText
-from email.mime.multipart import MIMEMultipart
-import time
 import generate_report
+from .email_utils import send_threshold_email
 
 # ``dash`` is optional during testing so fall back to light stubs when missing.
 try:  # pragma: no cover - optional dependency
@@ -95,7 +92,6 @@ from .settings import (
     convert_capacity_from_kg,
     capacity_unit_label,
     load_threshold_settings,
-    load_email_settings,
     load_language_preference,
     load_weight_preference,
     load_theme_preference,
@@ -171,50 +167,9 @@ def _ordinal_suffix(n: int) -> str:
         suffix = {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
     return f"{n}{suffix}"
 
+# ``send_threshold_email`` is provided by ``email_utils`` to avoid duplication.
 
-def send_threshold_email(sensitivity_num: int, is_high: bool = True) -> bool:
-    """Send an email notification for a threshold violation."""
-    try:
-        email_address = threshold_settings.get("email_address", "")
-        if not email_address:
-            logger.warning("No email address configured for notifications")
-            return False
 
-        msg = MIMEMultipart()
-        msg["Subject"] = "Enpresor Alarm"
-        msg["From"] = "jcantu@satake-usa.com"
-        msg["To"] = email_address
-
-        threshold_type = "upper" if is_high else "lower"
-        body = (
-            f"Sensitivity {sensitivity_num} has reached the {threshold_type} threshold."
-        )
-        msg.attach(MIMEText(body, "plain"))
-
-        logger.info(f"Sending email to {email_address}: {body}")
-
-        email_settings = load_email_settings()
-        server_addr = email_settings.get(
-            "smtp_server", DEFAULT_EMAIL_SETTINGS["smtp_server"]
-        )
-        port = email_settings.get("smtp_port", DEFAULT_EMAIL_SETTINGS["smtp_port"])
-        server = smtplib.SMTP(server_addr, port)
-        server.starttls()
-        username = email_settings.get("smtp_username")
-        password = email_settings.get("smtp_password")
-        if username and password:
-            server.login(username, password)
-
-        from_addr = email_settings.get(
-            "from_address", DEFAULT_EMAIL_SETTINGS["from_address"]
-        )
-        text = msg.as_string()
-        server.sendmail(from_addr, email_address, text)
-        server.quit()
-        return True
-    except Exception as e:  # pragma: no cover - just log
-        logger.error(f"Error sending threshold email: {e}")
-        return False
 
 
 #@_dash_callback(

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tests.test_callbacks import load_callbacks
+
+
+def test_send_threshold_email(monkeypatch):
+    callbacks, _ = load_callbacks(monkeypatch)
+    callbacks.threshold_settings = {"email_address": "user@example.com"}
+    monkeypatch.setitem(sys.modules, "dashboard.callbacks", callbacks)
+
+    import dashboard.email_utils as email_utils
+
+    monkeypatch.setattr(
+        email_utils,
+        "email_settings",
+        {
+            "smtp_server": "smtp.example.com",
+            "smtp_port": 25,
+            "smtp_username": "",
+            "smtp_password": "",
+            "from_address": "from@example.com",
+        },
+        raising=False,
+    )
+
+    captured = {}
+
+    class DummySMTP:
+        def __init__(self, host, port):
+            captured["host"] = host
+            captured["port"] = port
+
+        def starttls(self):
+            captured["tls"] = True
+
+        def login(self, username, password):
+            captured["login"] = (username, password)
+
+        def sendmail(self, from_addr, to_addr, msg):
+            captured["mail"] = (from_addr, to_addr, msg)
+
+        def quit(self):
+            captured["quit"] = True
+
+    monkeypatch.setattr(email_utils.smtplib, "SMTP", DummySMTP)
+
+    result = email_utils.send_threshold_email(3, is_high=False)
+    assert result is True
+    assert captured["host"] == "smtp.example.com"
+    assert captured["port"] == 25
+    assert captured["mail"][0] == "from@example.com"
+    assert captured["mail"][1] == "user@example.com"
+    assert "lower" in captured["mail"][2]


### PR DESCRIPTION
## Summary
- import `send_threshold_email` from `email_utils` within callbacks
- remove duplicate email function and unused imports
- add tests for email helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f47b8d43c832784a5c109c35c1383